### PR TITLE
TOPO-1959: Expose UBURLDataTask.countOfBytesReceived

### DIFF
--- a/Sources/UBFoundation/Networking/UBURLDataTask.swift
+++ b/Sources/UBFoundation/Networking/UBURLDataTask.swift
@@ -59,6 +59,11 @@ public final class UBURLDataTask: UBURLSessionTask, CustomStringConvertible, Cus
         return progress
     }
 
+    /// :nodoc:
+    public var countOfBytesReceived: Int64 {
+        dataTask?.countOfBytesReceived ?? 0
+    }
+
     /// The underlaying data task
     private var dataTask: URLSessionDataTask?
 


### PR DESCRIPTION
Use case:

We would like to guard against files that are too large. We first check the content-length using a head request. Because this content length might not be set or wrong, we want to check the countOfReceivedBytes in a progress observer:


```swift
downloadTask?.addProgressObserver { [weak self] task, _ in
          if task.countOfBytesReceived > Self.maxFileSizeBytes {
              task.cancel()
              self?.showError(error: TourDownloadError.fileSizeTooLarge, message: "Datei zu gross")
          }
      }
```