### PR TITLE
Add region monitoring to UBLocationManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can aslo find plenty of guides under the Documentation folder in the project
 
 # UBLocation
 
-A `UBLocationManager` facilitates asking for the required authorization level for the desired usage (location, significant updates, visits or heading). The location manager forwards the updates to the client's `UBLocationManagerDelegate`, similar to the `CLLocationManagerDelegate`.
+A `UBLocationManager` facilitates asking for the required authorization level for the desired usage (location, significant updates, visits, heading or region monitoring). The location manager forwards the updates to the client's `UBLocationManagerDelegate`, similar to the `CLLocationManagerDelegate`.
 
 ## Usage
 

--- a/Sources/UBLocation/UBLocationManager.swift
+++ b/Sources/UBLocation/UBLocationManager.swift
@@ -317,7 +317,9 @@ public class UBLocationManager: NSObject {
         }
         if usage.containsRegions {
             for region in usage.regionsToMonitor {
-                locationManager.startMonitoring(for: region)
+                if !locationManager.monitoredRegions.contains(region) {
+                    locationManager.startMonitoring(for: region)
+                }
             }
         }
     }
@@ -440,7 +442,9 @@ public class UBLocationManager: NSObject {
         }
         if usage.containsRegions {
             for region in usage.regionsToMonitor {
-                locationManager.startMonitoring(for: region)
+                if !locationManager.monitoredRegions.contains(region) {
+                    locationManager.startMonitoring(for: region)
+                }
             }
         }
     }

--- a/Sources/UBLocation/UBLocationManager.swift
+++ b/Sources/UBLocation/UBLocationManager.swift
@@ -675,7 +675,7 @@ extension Set where Element == UBLocationManager.LocationMonitoringUsage {
 
     /// :nodoc:
     var containsLocation: Bool {
-        contains(.location(background: true)) || contains(.location(background: false))
+        contains(.foregroundLocation) || contains(.backgroundLocation)
     }
 
     /// :nodoc:

--- a/Sources/UBLocation/UBLocationManager.swift
+++ b/Sources/UBLocation/UBLocationManager.swift
@@ -24,6 +24,10 @@ public protocol UBLocationManagerDelegate: CLLocationManagerDelegate {
     func locationManager(_ manager: UBLocationManager, didVisit visit: CLVisit)
     /// :nodoc:
     func locationManager(_ manager: UBLocationManager, didFailWithError error: Error)
+    /// :nodoc:
+    func locationManager(_ manager: UBLocationManager, didEnterRegion region: CLRegion)
+    /// :nodoc:
+    func locationManager(_ manager: UBLocationManager, didExitRegion region: CLRegion)
 
     /// If set, the locations returned for this delegate will be filtered for the given accuracy
     var locationManagerFilterAccuracy: CLLocationAccuracy? { get }
@@ -41,6 +45,8 @@ public extension UBLocationManagerDelegate {
     func locationManager(_: UBLocationManager, didUpdateLocations _: [CLLocation]) {}
     func locationManager(_: UBLocationManager, didUpdateHeading _: CLHeading) {}
     func locationManager(_: UBLocationManager, didVisit _: CLVisit) {}
+    func locationManager(_: UBLocationManager, didEnterRegion region: CLRegion) {}
+    func locationManager(_: UBLocationManager, didExitRegion region: CLRegion) {}
     var locationManagerMaxFreshAge: TimeInterval? { nil }
     func locationManager(_: UBLocationManager, locationIsFresh _: Bool) {}
 }
@@ -59,7 +65,7 @@ public class UBLocationManager: NSObject {
     }
 
     private var permissionRequestCallback: ((LocationPermissionRequestResult) -> Void)?
-    private var permissionRequestUsage: LocationMonitoringUsage?
+    private var permissionRequestUsage: Set<LocationMonitoringUsage>?
 
     @UBUserDefault(key: "UBLocationManager_askedForAlwaysAtLeastOnce", defaultValue: false)
     private var askedForAlwaysPermissionAtLeastOnce: Bool
@@ -75,7 +81,7 @@ public class UBLocationManager: NSObject {
     }
 
     /// The union of the usages for all the delegaets
-    private var usage: LocationMonitoringUsage {
+    private var usage: Set<LocationMonitoringUsage> {
         delegateWrappers.values
             .map(\.usage)
             .reduce([]) { $0.union($1) }
@@ -127,6 +133,16 @@ public class UBLocationManager: NSObject {
         }
     }
 
+    /// The set of regions that are currently being monitored.
+    public var monitoredRegions: Set<CLRegion> {
+        locationManager.monitoredRegions
+    }
+
+    /// The maximum region size, in terms of a distance from a central point, that the framework can support.
+    public var maximumRegionMonitoringDistance: CLLocationDistance {
+        locationManager.maximumRegionMonitoringDistance
+    }
+
     /// Indicates whether the app should receive location updates when suspended.
     /// Setting this to `true` requires setting `UIBackgroundModes` to `location` in `Info.plist`
     public var allowsBackgroundLocationUpdates: Bool {
@@ -167,7 +183,7 @@ public class UBLocationManager: NSObject {
     private var lastDelegateFreshState: [ObjectIdentifier: Bool] = [:]
 
     /// Does the location manager have the required authorization level for `usage`?
-    public static func hasRequiredAuthorizationLevel(forUsage usage: LocationMonitoringUsage) -> Bool {
+    public static func hasRequiredAuthorizationLevel(forUsage usage: Set<LocationMonitoringUsage>) -> Bool {
         let authorizationStatus = CLLocationManager.authorizationStatus()
         switch authorizationStatus {
             case .authorizedAlways:
@@ -186,6 +202,11 @@ public class UBLocationManager: NSObject {
             @unknown default:
                 fatalError()
         }
+    }
+
+    /// Does the location manager have the required authorization level for `usage`?
+    public static func hasRequiredAuthorizationLevel(forUsage usage: LocationMonitoringUsage) -> Bool {
+        hasRequiredAuthorizationLevel(forUsage: Set([usage]))
     }
 
     /// The underlying location manager
@@ -230,9 +251,9 @@ public class UBLocationManager: NSObject {
     /// Start monitoring location service events (varies by `usage`)
     ///
     /// - Parameters:
-    ///   - usage: The desired usage. Can also be an array, e.g. `[.location(background: false), .heading(background: true)]`
+    ///   - usage: The desired usage, e.g. `[.location(background: false), .heading(background: true)]`
     ///   - canAskForPermission: Whether the location manager can ask for the required permission on its own behalf
-    public func startLocationMonitoring(for usage: LocationMonitoringUsage, delegate: UBLocationManagerDelegate, canAskForPermission: Bool) {
+    public func startLocationMonitoring(for usage: Set<LocationMonitoringUsage>, delegate: UBLocationManagerDelegate, canAskForPermission: Bool) {
         let wrapper = UBLocationManagerDelegateWrapper(delegate, usage: usage)
         let id = ObjectIdentifier(delegate)
         delegateWrappers[id] = wrapper
@@ -269,6 +290,15 @@ public class UBLocationManager: NSObject {
         }
     }
 
+    /// Start monitoring location service events (varies by `usage`)
+    ///
+    /// - Parameters:
+    ///   - usage: The desired usage, e.g. `.location(background: false)`
+    ///   - canAskForPermission: Whether the location manager can ask for the required permission on its own behalf
+    public func startLocationMonitoring(for usage: LocationMonitoringUsage, delegate: UBLocationManagerDelegate, canAskForPermission: Bool) {
+        startLocationMonitoring(for: Set([usage]), delegate: delegate, canAskForPermission: canAskForPermission)
+    }
+
     /// Restart any monitoring that's used by a delegate.
     /// This method can be called as a safety measure to ensure location updates
     /// A good place to call this method is a location button in map app
@@ -285,6 +315,11 @@ public class UBLocationManager: NSObject {
         if usage.containsHeading {
             locationManager.startUpdatingHeading()
         }
+        if usage.containsRegions {
+            for region in usage.regionsToMonitor {
+                locationManager.startMonitoring(for: region)
+            }
+        }
     }
 
     /// Stops monitoring location service events and removes the delegate
@@ -300,7 +335,7 @@ public class UBLocationManager: NSObject {
     }
 
     /// Stops monitoring all location service events
-    private func stopLocationMonitoring(_ usage: LocationMonitoringUsage? = nil) {
+    private func stopLocationMonitoring(_ usage: Set<LocationMonitoringUsage>? = nil) {
         let usage = usage ?? self.usage
 
         timedOut = false
@@ -319,6 +354,11 @@ public class UBLocationManager: NSObject {
         if usage.containsHeading {
             locationManager.stopUpdatingHeading()
         }
+        if usage.containsRegions {
+            for region in usage.regionsToMonitor {
+                locationManager.stopMonitoring(for: region)
+            }
+        }
     }
 
     /// Permission request to get state of location permission (varies by `usage`)
@@ -326,7 +366,7 @@ public class UBLocationManager: NSObject {
     /// - Parameters:
     ///   - usage: The desired usage.
     ///   - callback: Asynchronous callback with result.
-    public func requestPermission(for usage: LocationMonitoringUsage, callback: @escaping ((LocationPermissionRequestResult) -> Void)) {
+    public func requestPermission(for usage: Set<LocationMonitoringUsage>, callback: @escaping ((LocationPermissionRequestResult) -> Void)) {
         // if it's already running, callback .failed & continue
         if self.permissionRequestCallback != nil {
             self.permissionRequestCallback?(.failure)
@@ -368,6 +408,15 @@ public class UBLocationManager: NSObject {
         }
     }
 
+    /// Permission request to get state of location permission (varies by `usage`)
+    ///
+    /// - Parameters:
+    ///   - usage: The desired usage.
+    ///   - callback: Asynchronous callback with result.
+    public func requestPermission(for usage: LocationMonitoringUsage, callback: @escaping ((LocationPermissionRequestResult) -> Void)) {
+        requestPermission(for: Set([usage]), callback: callback)
+    }
+
     /// :nodoc:
     private func startLocationMonitoringWithoutChecks(_ delegate: UBLocationManagerDelegate) {
         guard locationManager.locationServicesEnabled() else {
@@ -388,6 +437,11 @@ public class UBLocationManager: NSObject {
         }
         if usage.containsHeading {
             locationManager.startUpdatingHeading()
+        }
+        if usage.containsRegions {
+            for region in usage.regionsToMonitor {
+                locationManager.startMonitoring(for: region)
+            }
         }
     }
 
@@ -519,6 +573,18 @@ extension UBLocationManager: CLLocationManagerDelegate {
         }
     }
 
+    public func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
+        for delegate in delegates {
+            delegate.locationManager(self, didEnterRegion: region)
+        }
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
+        for delegate in delegates {
+            delegate.locationManager(self, didExitRegion: region)
+        }
+    }
+
     public func locationManager(_: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
         lastHeading = newHeading
         for delegate in delegates {
@@ -551,57 +617,70 @@ public extension UBLocationManager {
     }
 
     /// Defines the usage for `UBLocationManager`. Can be a combination of the defined options.
-    struct LocationMonitoringUsage: OptionSet {
-        public let rawValue: UInt8
-
-        public init(rawValue: UInt8) {
-            self.rawValue = rawValue
-        }
-
-        /// :nodoc:
-        public var requiresBackgroundLocation: Bool {
-            contains(.backgroundLocation) || contains(.backgroundHeading)
-        }
+    enum LocationMonitoringUsage: Equatable, Hashable {
+        case foregroundLocation
+        case backgroundLocation
+        case foregroundHeading
+        case backgroundHeading
+        case significantChange
+        case visits
+        case regions(Set<CLRegion>)
 
         /// Monitors location
         public static func location(background: Bool) -> LocationMonitoringUsage {
             background ? .backgroundLocation : .foregroundLocation
         }
 
-        private static let foregroundLocation = LocationMonitoringUsage(rawValue: 1 << 0)
-        private static let backgroundLocation = LocationMonitoringUsage(rawValue: 1 << 1)
-
         /// Monitors heading
         public static func heading(background: Bool) -> LocationMonitoringUsage {
             background ? .backgroundHeading : .foregroundHeading
         }
+    }
+}
 
-        private static let foregroundHeading = LocationMonitoringUsage(rawValue: 1 << 3)
-        private static let backgroundHeading = LocationMonitoringUsage(rawValue: 1 << 2)
+extension Set where Element == UBLocationManager.LocationMonitoringUsage {
+    /// :nodoc:
+    var requiresBackgroundLocation: Bool {
+        contains(.backgroundLocation) || contains(.backgroundHeading)
+    }
 
-        /// Monitors significant location changes
-        public static let significantChange = LocationMonitoringUsage(rawValue: 1 << 4)
-        /// Monitors visits
-        public static let visits = LocationMonitoringUsage(rawValue: 1 << 5)
-
-        /// :nodoc:
-        public var minimumAuthorizationLevelRequired: AuthorizationLevel {
-            if contains(.significantChange) || contains(.visits) || requiresBackgroundLocation {
-                return AuthorizationLevel.always
-            } else {
-                return AuthorizationLevel.whenInUse
+    /// :nodoc:
+    var containsRegions: Bool {
+        for element in self {
+            if case .regions = element {
+                return true
             }
         }
+        return false
+    }
 
-        /// :nodoc:
-        public var containsLocation: Bool {
-            contains(.location(background: true)) || contains(.location(background: false))
+    var regionsToMonitor: Set<CLRegion> {
+        var regions = Set<CLRegion>()
+        for element in self {
+            if case let .regions(r) = element {
+                regions.formUnion(r)
+            }
         }
+        return regions
+    }
 
-        /// :nodoc:
-        public var containsHeading: Bool {
-            contains(.heading(background: true)) || contains(.heading(background: false))
+    /// :nodoc:
+    var minimumAuthorizationLevelRequired: UBLocationManager.AuthorizationLevel {
+        if contains(.significantChange) || contains(.visits) || containsRegions || requiresBackgroundLocation {
+            return .always
+        } else {
+            return .whenInUse
         }
+    }
+
+    /// :nodoc:
+    var containsLocation: Bool {
+        contains(.location(background: true)) || contains(.location(background: false))
+    }
+
+    /// :nodoc:
+    var containsHeading: Bool {
+        contains(.foregroundHeading) || contains(.backgroundHeading)
     }
 }
 

--- a/Sources/UBLocation/UBLocationManagerDelegateWrapper.swift
+++ b/Sources/UBLocation/UBLocationManagerDelegateWrapper.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 class UBLocationManagerDelegateWrapper {
-    let usage: UBLocationManager.LocationMonitoringUsage
+    let usage: Set<UBLocationManager.LocationMonitoringUsage>
 
     weak var delegate: UBLocationManagerDelegate?
 
-    init(_ delegate: UBLocationManagerDelegate, usage: UBLocationManager.LocationMonitoringUsage) {
+    init(_ delegate: UBLocationManagerDelegate, usage: Set<UBLocationManager.LocationMonitoringUsage>) {
         self.delegate = delegate
         self.usage = usage
     }

--- a/Sources/UBLocation/UBLocationManagerProtocol.swift
+++ b/Sources/UBLocation/UBLocationManagerProtocol.swift
@@ -21,6 +21,8 @@ public protocol UBLocationManagerProtocol {
     var pausesLocationUpdatesAutomatically: Bool { get set }
     @available(iOS 11.0, *)
     var showsBackgroundLocationIndicator: Bool { get set }
+    var monitoredRegions: Set<CLRegion> { get }
+    var maximumRegionMonitoringDistance: CLLocationDistance { get }
 
     // Starting / stopping updates
     func startUpdatingLocation()
@@ -29,6 +31,8 @@ public protocol UBLocationManagerProtocol {
     func stopMonitoringSignificantLocationChanges()
     func startMonitoringVisits()
     func stopMonitoringVisits()
+    func startMonitoring(for region: CLRegion)
+    func stopMonitoring(for region: CLRegion)
     func startUpdatingHeading()
     func stopUpdatingHeading()
 
@@ -39,6 +43,7 @@ public protocol UBLocationManagerProtocol {
     func authorizationStatus() -> CLAuthorizationStatus
     func locationServicesEnabled() -> Bool
     func significantLocationChangeMonitoringAvailable() -> Bool
+    func isMonitoringAvailable(for regionClass: AnyClass) -> Bool
 }
 
 extension CLLocationManager: UBLocationManagerProtocol {
@@ -52,5 +57,9 @@ extension CLLocationManager: UBLocationManagerProtocol {
 
     public func significantLocationChangeMonitoringAvailable() -> Bool {
         CLLocationManager.significantLocationChangeMonitoringAvailable()
+    }
+
+    public func isMonitoringAvailable(for regionClass: AnyClass) -> Bool {
+        CLLocationManager.isMonitoringAvailable(for: regionClass)
     }
 }

--- a/Tests/UBLocationTests/MockLocationManager.swift
+++ b/Tests/UBLocationTests/MockLocationManager.swift
@@ -28,6 +28,8 @@ class MockLocationManager: UBLocationManagerProtocol {
 
     var isUpdatingHeading: Bool = false
 
+    var monitoredRegions: Set<CLRegion> = Set()
+
     // MARK: - UBLocationManagerProtocol properties
 
     var location: CLLocation? {
@@ -42,6 +44,7 @@ class MockLocationManager: UBLocationManagerProtocol {
     var allowsBackgroundLocationUpdates: Bool = false
     var pausesLocationUpdatesAutomatically: Bool = false
     var showsBackgroundLocationIndicator: Bool = false
+    var maximumRegionMonitoringDistance: CLLocationDistance = CLLocationManager().maximumRegionMonitoringDistance
 
     // MARK: - Starting / stopping location services
 
@@ -77,6 +80,14 @@ class MockLocationManager: UBLocationManagerProtocol {
         isUpdatingHeading = false
     }
 
+    func startMonitoring(for region: CLRegion) {
+        monitoredRegions.insert(region)
+    }
+
+    func stopMonitoring(for region: CLRegion) {
+        monitoredRegions.remove(region)
+    }
+
     // MARK: - Authorization
 
     func requestWhenInUseAuthorization() {
@@ -98,6 +109,10 @@ class MockLocationManager: UBLocationManagerProtocol {
     }
 
     func significantLocationChangeMonitoringAvailable() -> Bool {
+        true
+    }
+
+    func isMonitoringAvailable(for regionClass: AnyClass) -> Bool {
         true
     }
 }


### PR DESCRIPTION
This PR adds the option to monitor regions to `UBLocationManager`. It wraps the existing region monitoring functionality of `CLLocationManager` (https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions).

Since this is the first type of usage that requires passing arguments (a set of `CLRegion` objects), I refactored the `LocationMonitoringUsage` type from an OptionSet to an enum. The downside of this is that now some methods need two versions (one with a single `LocationMonitoringUsage` and one with an array) in order not to break existing code. Apart from that, the change should not be breaking (unless someone used the `LocationMonitoringUsage` OptionSet type somewhere in an unexpected fashion).