### PR TITLE
Evaluate all QR codes not only the first one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- The QRScannerView now evaluates all QR-codes not only the first one found. Therefore the qrScanningDidSucceedWithCode has to return a bool wether this QR-Code was usable or not.
 
 ## 1.2.0
 ### Added

--- a/Sources/UBQRScanner/QRScannerView.swift
+++ b/Sources/UBQRScanner/QRScannerView.swift
@@ -184,8 +184,8 @@ public class QRScannerView: UIView {
         captureSession = nil
     }
 
-    private func found(code: String) {
-        delegate?.qrScanningDidSucceedWithCode(code)
+    private func found(code: String) -> Bool {
+        delegate?.qrScanningDidSucceedWithCode(code) ?? false
     }
 }
 
@@ -193,10 +193,12 @@ extension QRScannerView: AVCaptureMetadataOutputObjectsDelegate {
     public func metadataOutput(_: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from _: AVCaptureConnection) {
         guard !isScanningPaused else { return } // Don't process any input if scanning is paused
 
-        if let metadataObject = metadataObjects.first {
-            guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
-            guard let stringValue = readableObject.stringValue else { return }
-            found(code: stringValue)
+        for metadataObject in metadataObjects {
+            guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { continue }
+            guard let stringValue = readableObject.stringValue else { continue }
+            if found(code: stringValue) {
+                return
+            }
         }
     }
 }

--- a/Sources/UBQRScanner/QRScannerViewDelegate.swift
+++ b/Sources/UBQRScanner/QRScannerViewDelegate.swift
@@ -11,6 +11,7 @@ import Foundation
 /// like successfully scanned codes or errors
 public protocol QRScannerViewDelegate: AnyObject {
     func qrScanningDidFailWithError(_ error: QRScannerError)
-    func qrScanningDidSucceedWithCode(_ code: String?)
+    // if true is returned no more codes will be passed to this delegate from the current frame
+    func qrScanningDidSucceedWithCode(_ code: String?) -> Bool
     func qrScanningDidStop()
 }


### PR DESCRIPTION
Currently only the first recognized QR-Code will be passed to the delegate. 