### PR TITLE
Print errorCode from UBCodedError

### DIFF
--- a/Sources/UBFoundation/Networking/Networking+Error.swift
+++ b/Sources/UBFoundation/Networking/Networking+Error.swift
@@ -54,8 +54,8 @@ public enum UBInternalNetworkingError: LocalizedError, Equatable {
     case recoverableError(UBNetworkTaskRecoveryOptions)
     /// Failed to unwrap an optional (should never happen)
     case unwrapError
-    /// Other error from NSURLErrorDomain
-    case otherNSURLError(NSError)
+    /// Other error
+    case otherError(NSError)
 }
 
 /// A structure that encapsulate the error body returned from the backend
@@ -80,7 +80,7 @@ extension UBNetworkingError {
             case let error as UBNetworkTaskRecoveryOptions:
                 self = UBNetworkingError.internal(.recoverableError(error))
             case let error as NSError:
-                let otherError = UBInternalNetworkingError.otherNSURLError(error)
+                let otherError = UBInternalNetworkingError.otherError(error)
                 self = .internal(otherError)
         }
     }
@@ -122,7 +122,12 @@ extension UBInternalNetworkingError: UBCodedError {
                 case .synchronousTimedOut: return "SEMTIMEOUT"
                 case .canceled: return "CANCELLED"
                 case .recoverableError: return "REC"
-                case let .otherNSURLError(error): return "NSURL \(error.code)"
+                case let .otherError(error):
+                    if let codedError = error as? UBCodedError {
+                        return codedError.errorCode
+                    } else {
+                        return "NSURL: \(error.localizedDescription) [\(error.code)]"
+                    }
             }
         }()
         return "\(errorCodePrefix)\(postfix)"

--- a/Tests/UBFoundationTests/Networking/UBSessionTests.swift
+++ b/Tests/UBFoundationTests/Networking/UBSessionTests.swift
@@ -110,7 +110,7 @@ class UBSessionTests: XCTestCase {
                 case .success:
                     XCTFail()
                 case let .failure(error):
-                    XCTAssertEqual(error, UBNetworkingError.internal(.otherNSURLError(Err.x as NSError)))
+                    XCTAssertEqual(error, UBNetworkingError.internal(.otherError(Err.x as NSError)))
             }
             ex.fulfill()
         }


### PR DESCRIPTION
If an error happens within the UBNetworking machinery (e.g. adding request modifiers) we can throw any errors, specifically `UBCodedError` which provides an error description.

Currently, this error description was discarded in favour of `NSError.code` which makes it impossible to propagate multiple inner errors.

In this PR the `otherNSUrlError` is renamed to `otherError`. Further, in `errorCode` getter, the `NSError` is checked for conformance to the `UBCodedError` protocol. If so, the inner error is displayed.