### PR TITLE
fixes user defaults bool decoding

### DIFF
--- a/Sources/UBFoundation/Storage/UBUserDefault/UBUserDefault.swift
+++ b/Sources/UBFoundation/Storage/UBUserDefault/UBUserDefault.swift
@@ -42,7 +42,6 @@ extension Date: UBPListValue {}
 extension NSDate: UBPListValue {}
 
 extension NSNumber: UBPListValue {}
-extension Bool: UBPListValue {}
 extension Int: UBPListValue {}
 extension Int8: UBPListValue {}
 extension Int16: UBPListValue {}
@@ -55,6 +54,36 @@ extension UInt32: UBPListValue {}
 extension UInt64: UBPListValue {}
 extension Double: UBPListValue {}
 extension Float: UBPListValue {}
+
+// MARK: - Bool
+
+extension Bool: UBUserDefaultValue {
+    public init?(with object: Any) {
+        if let value = object as? Self {
+            self = value
+            return
+        }
+
+        // If a UserDefault value is passed via launchArgument for XCUITest it is always passed as a string
+        // therefore we try to interpret the string as a fallback
+        if let string = object as? String {
+            switch string.lowercased() {
+            case "true", "t", "yes", "y", "1":
+                self = true
+                return
+            case "false", "f", "no", "n", "0":
+                self = false
+                return
+            default:
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    public func object() -> Any? { self }
+}
 
 // MARK: - Codable Values
 

--- a/Sources/UBFoundation/Storage/UBUserDefault/UBUserDefault.swift
+++ b/Sources/UBFoundation/Storage/UBUserDefault/UBUserDefault.swift
@@ -68,14 +68,14 @@ extension Bool: UBUserDefaultValue {
         // therefore we try to interpret the string as a fallback
         if let string = object as? String {
             switch string.lowercased() {
-            case "true", "t", "yes", "y", "1":
-                self = true
-                return
-            case "false", "f", "no", "n", "0":
-                self = false
-                return
-            default:
-                return nil
+                case "true", "t", "yes", "y", "1":
+                    self = true
+                    return
+                case "false", "f", "no", "n", "0":
+                    self = false
+                    return
+                default:
+                    return nil
             }
         }
 


### PR DESCRIPTION
If a UserDefault value is passed via launchArgument for XCUITest it is always passed as a string therefore we try to interpret the string as a fallback. https://github.com/admin-ch/CovidCertificate-App-iOS/blob/main/CovidCertificate/SharedUI/Helpers/UBUserDefault/UBUserDefault.swift#L63-L89