### PR TITLE
Fix UBPopup

### DIFF
--- a/Sources/UBFoundation/Networking/Concurrency/UBURLDataTask+Concurrency.swift
+++ b/Sources/UBFoundation/Networking/Concurrency/UBURLDataTask+Concurrency.swift
@@ -206,7 +206,6 @@ public extension UBURLDataTask {
         await UBURLDataTask.loadOnce(request: request, decoder: UBDataPassthroughDecoder(), ignoreCache: ignoreCache, taskConfig: taskConfig)
     }
 
-
     /// Makes a request and returns a TaskResult consisting of Data
     /// - Parameters:
     ///   - url: A URL that represents the request to execute.
@@ -373,6 +372,4 @@ public extension UBURLDataTask.TaskConfig {
     func loadOnce(url: URL, ignoreCache: Bool = false) async -> UBURLDataTask.TaskResult<Data> {
         await UBURLDataTask.loadOnce(request: UBURLRequest(url: url), decoder: UBDataPassthroughDecoder(), ignoreCache: ignoreCache, taskConfig: self)
     }
-
 }
-

--- a/Sources/UBFoundation/Networking/UBURLDataTask.swift
+++ b/Sources/UBFoundation/Networking/UBURLDataTask.swift
@@ -442,7 +442,6 @@ public final class UBURLDataTask: UBURLSessionTask, CustomStringConvertible, Cus
                 observer(old, new, self)
             }
         }
-
     }
 
     /// Add an observer that gets called when the state changes. This observer will be called on the specified callback thread.

--- a/Sources/UBFoundation/Observer/UBObserver.swift
+++ b/Sources/UBFoundation/Observer/UBObserver.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-extension NotificationCenter {
+public extension NotificationCenter {
     /// Adds an entry to the notification center to receive notifications that passed to the provided block. This is a managed observation
     /// that will be ended as soon as the reference returned object is deallocated.
     ///
@@ -19,7 +19,7 @@ extension NotificationCenter {
     ///   The notification center copies the block. The notification center strongly holds the copied block until you remove the observer registration.
     ///   The block takes one argument: the notification.
     /// - Returns: An opaque object to act as the observer. You must strongly holds to this return value unless it will be deallocated and the observation is removed.
-    public func addUBObserver(forName name: NSNotification.Name?, object: Any? = nil, queue: OperationQueue? = .main, using block: @escaping (Notification) -> Void) -> Any {
+    func addUBObserver(forName name: NSNotification.Name?, object: Any? = nil, queue: OperationQueue? = .main, using block: @escaping (Notification) -> Void) -> Any {
         let reference = self.addObserver(forName: name, object: object, queue: queue, using: block)
         let token = NotificationCenterObservationHolder(reference: reference, notificationCenter: self)
         return token

--- a/Sources/UBUserInterface/SwiftUI/Popup/UBPopupContainerView.swift
+++ b/Sources/UBUserInterface/SwiftUI/Popup/UBPopupContainerView.swift
@@ -54,11 +54,6 @@
             }
             .transition(.opacity)
             .animation(.default, value: isPresented)
-            .onChange(of: isPresented) { newValue in
-                if !newValue {
-                    UBPopupWindowManager.shared.hideWindow()
-                }
-            }
         }
     }
 

--- a/Sources/UBUserInterface/SwiftUI/Popup/UBPopupWindowManager.swift
+++ b/Sources/UBUserInterface/SwiftUI/Popup/UBPopupWindowManager.swift
@@ -44,6 +44,9 @@
 
         func hideWindow() {
             window?.isUserInteractionEnabled = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                self.hostingController.rootView = UBPopupContainerView(isPresented: .constant(false), style: .init(), content: { AnyView(EmptyView()) })
+            }
         }
     }
 

--- a/Sources/UBUserInterface/SwiftUI/Popup/UBPopupWrapper.swift
+++ b/Sources/UBUserInterface/SwiftUI/Popup/UBPopupWrapper.swift
@@ -28,6 +28,8 @@
                 .onPreferenceChange(UBPopupPreferenceKey.self) { popupPreference in
                     if let popupPreference, popupPreference.isPresented.wrappedValue {
                         UBPopupWindowManager.shared.showPopup(isPresented: popupPreference.isPresented, style: popupPreference.customStyle ?? style, content: popupPreference.content)
+                    } else {
+                        UBPopupWindowManager.shared.hideWindow()
                     }
                 }
         }

--- a/Tests/UBFoundationTests/Networking/ConcurrentNetworkTests.swift
+++ b/Tests/UBFoundationTests/Networking/ConcurrentNetworkTests.swift
@@ -6,12 +6,11 @@
 //
 
 import UBFoundation
-import XCTest
 import UBLocalNetworking
+import XCTest
 
 @available(iOS 15.0.0, *)
 class ConcurrentNetworkTests: XCTestCase {
-
     private let sampleUrl = URL(string: "http://mock.ubique.ch/user.json")!
     private lazy var sampleRequest = UBURLRequest(url: sampleUrl)
 
@@ -23,7 +22,7 @@ class ConcurrentNetworkTests: XCTestCase {
         let request = UBURLRequest(url: url)
         return request
     }
-    
+
     private struct User: Encodable {
         let name: String
     }
@@ -54,7 +53,7 @@ class ConcurrentNetworkTests: XCTestCase {
             "x-amz-meta-cache": "max-age=300",
             "x-amz-version-id": "qSojcs_cgESN8uLviKqiyCiFauZY0kxw",
             "x-amz-meta-next-refresh": "Mon, 06 Feb 2023 14:06:01 GMT",
-            "Date": UBBaseCachingLogic().dateFormatter.string(from: Date())
+            "Date": UBBaseCachingLogic().dateFormatter.string(from: Date()),
         ]))
         cronResponseProvider.addToLocalServer()
     }

--- a/Tests/UBFoundationTests/Observer/UBObserverTests.swift
+++ b/Tests/UBFoundationTests/Observer/UBObserverTests.swift
@@ -1,15 +1,14 @@
 //
 //  UBObserverTests.swift
-//  
+//
 //
 //  Created by Joseph El Mallah on 10.02.23.
 //
 
-import XCTest
 import UBFoundation
+import XCTest
 
 final class UBObserverTests: XCTestCase {
-
     private var reference: Any?
 
     func testManagedNotificationCenterObservationRemoval() {
@@ -26,5 +25,4 @@ final class UBObserverTests: XCTestCase {
         notificationCenter.post(name: notificationName, object: nil)
         wait(for: [expectation], timeout: 1)
     }
-
 }


### PR DESCRIPTION
Problem vorher: Wenn das Popup zwar verschwindet durch das setzen des Bindings auf `false`, aber nicht entfernt wird, lebt es noch weiter und beim nächsten Popup-Aufruf (also beim nächsten Mal `isPresented = true`) gibt es dann zwei Views, welche beide auf dasselbe Binding hören und sich gegenseitig beeinflussen.