### PR TITLE
Make UBNetworkingError init public for non-ub datatasks

### DIFF
--- a/Sources/UBFoundation/Networking/Networking+Error.swift
+++ b/Sources/UBFoundation/Networking/Networking+Error.swift
@@ -64,7 +64,7 @@ public protocol UBURLDataTaskErrorBody: Error {
     var baseError: Error? { get set }
 }
 
-extension UBNetworkingError {
+public extension UBNetworkingError {
     init(_ error: Error) {
         switch error {
             case let error as UBNetworkingError:


### PR DESCRIPTION
E.g. when using URLSessionDownloadTask, we still want to be able to display error codes