### PR TITLE
Adds 304 caching

### DIFF
--- a/Sources/UBFoundation/Networking/UBURLSession+Delegate.swift
+++ b/Sources/UBFoundation/Networking/UBURLSession+Delegate.swift
@@ -99,8 +99,14 @@ class UBURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDele
         // Execute the caching logic
         let cachedResponse = executeCachingLogic(cachingLogic: cachingLogic, session: session, task: task, ubDataTask: ubDataTask, request: collectedData.request, response: response, data: collectedData.data, metrics: collectedData.metrics, error: error)
 
+        var hasReceivedNotModified = false
+        if let m = collectedData.metrics {
+            let statusCodes = m.transactionMetrics.compactMap({ ($0.response as? HTTPURLResponse)?.statusCode })
+            hasReceivedNotModified = statusCodes.contains(UBStandardHTTPCode.notModified.rawValue)
+        }
+
         // If not modified return the cached data
-        if response.statusCode == UBStandardHTTPCode.notModified, let cached = collectedData.cached {
+        if hasReceivedNotModified, let cached = collectedData.cached {
             #if os(watchOS)
                 let info = UBNetworkingTaskInfo(cacheHit: true, refresh: ubDataTask.flags.contains(.ignoreCache))
             #else


### PR DESCRIPTION
- Die gecachede Response hat eigentlich immer einen 200er als Status Code
- So wird das "if 304" übersprungen
- Der Request wird als nicht gecached zurückgegeben, obwohl der Cache mit dem Server übereinstimmt (darum kam ja der 304)
- In den Transaction Metrics kann man rausfinden, ob ein 304er unterwegs vorkam

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced network caching by introducing a mechanism to detect `notModified` response status, optimizing data usage and improving load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->