### PR TITLE
Show dedicated error messages and codes for all network related errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "UBKit",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v11),
         .watchOS(.v5),

--- a/Sources/UBFoundation/Networking/NSError+ErrorCode.swift
+++ b/Sources/UBFoundation/Networking/NSError+ErrorCode.swift
@@ -12,7 +12,7 @@ extension NSError {
         if let codedError = self as? UBCodedError {
             return codedError.errorCode
         } else {
-            return "[\(self.mapDomain(self.domain))-\(self.code)]"
+            return "[\(self.mapDomain(self.domain))\(self.code)]"
         }
     }
 
@@ -20,10 +20,14 @@ extension NSError {
         switch domain {
             case "kCFErrorDomainCFNetwork":
                 return "CFN"
+            case "NSURLErrorDomain":
+                return "NSU"
             default:
                 if domain.contains("kCFErrorDomain") {
                     let domainPrefix = domain.replacingOccurrences(of: "kCFErrorDomain", with: "").replacingOccurrences(of: "CF", with: "").prefix(1)
                     return "CF\(domainPrefix)"
+                } else if domain.contains("ErrorDomain") {
+                    return domain.replacingOccurrences(of: "ErrorDomain", with: "")
                 }
                 return domain
         }

--- a/Sources/UBFoundation/Networking/UBURLDataTask.swift
+++ b/Sources/UBFoundation/Networking/UBURLDataTask.swift
@@ -596,7 +596,7 @@ public final class UBURLDataTask: UBURLSessionTask, CustomStringConvertible, Cus
         let waitResult = synchronousStartSemaphore.wait(timeout: DispatchTime.now() + DispatchTimeInterval.seconds(timeout))
 
         if waitResult == .timedOut {
-            return (Result.failure(.timedOut), nil, nil, self)
+            return (Result.failure(.timedOut()), nil, nil, self)
         }
 
         removeCompletionHandler(identifier: completionBlockIdentifier)

--- a/Sources/UBFoundation/Networking/UBURLSession+ServerTrustEvaluation.swift
+++ b/Sources/UBFoundation/Networking/UBURLSession+ServerTrustEvaluation.swift
@@ -118,7 +118,7 @@ public final class UBPinnedCertificatesTrustEvaluator: UBServerTrustEvaluator {
         let pinnedCertificatesData = Set(certificates.data)
         let pinnedCertificatesInServerData = !serverCertificatesData.isDisjoint(with: pinnedCertificatesData)
         if !pinnedCertificatesInServerData {
-            throw UBNetworkingError.certificateValidationFailed
+            throw UBNetworkingError.certificateValidationFailed()
         }
     }
 }
@@ -175,7 +175,7 @@ extension SecTrust {
         let status = SecTrustSetPolicies(self, policy)
 
         guard status.isSuccess else {
-            throw UBNetworkingError.certificateValidationFailed
+            throw UBNetworkingError.certificateValidationFailed()
         }
 
         return self
@@ -191,7 +191,7 @@ extension SecTrust {
         let status = SecTrustEvaluate(self, &result)
 
         guard status.isSuccess, result.isSuccess else {
-            throw UBNetworkingError.certificateValidationFailed
+            throw UBNetworkingError.certificateValidationFailed()
         }
     }
 
@@ -203,13 +203,13 @@ extension SecTrust {
         // Add additional anchor certificates.
         let status = SecTrustSetAnchorCertificates(self, certificates as CFArray)
         guard status.isSuccess else {
-            throw UBNetworkingError.certificateValidationFailed
+            throw UBNetworkingError.certificateValidationFailed()
         }
 
         // Reenable system anchor certificates.
         let systemStatus = SecTrustSetAnchorCertificatesOnly(self, true)
         guard systemStatus.isSuccess else {
-            throw UBNetworkingError.certificateValidationFailed
+            throw UBNetworkingError.certificateValidationFailed()
         }
     }
 

--- a/Sources/UBFoundation/Resources/de.lproj/Localizable.strings
+++ b/Sources/UBFoundation/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+"error_unexpected" = "Ein unerwarteter Fehler ist aufgetreten.";
+"error_invalid_certificate_message" = "Keine sichere Verbindung zum Server möglich. Bitte prüfen oder deaktivieren Sie Ihr VPN bzw. Ihren Proxy oder prüfen Sie, ob Sie über ein Public WLAN verbunden sind.";
+"error_code_prefix" = "Fehlercode:";
+"error_timeout" = "Anfrage-Timeout. Bitte überprüfen Sie Ihr Netzwerk und versuchen Sie es erneut.";
+"error_connection_failed" = "Verbindung zum Server konnte nicht hergestellt werden. Bitte überprüfen Sie Ihr Netzwerk und versuchen Sie es erneut.";

--- a/Sources/UBFoundation/Resources/en.lproj/Localizable.strings
+++ b/Sources/UBFoundation/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+"error_unexpected" = "An unexpected error has occurred.";
+"error_invalid_certificate_message" = "A secure connection cannot be made to the server. Please check or deactivate your VPN and/or your proxy or check whether you are connected via a public Wi-Fi network.";
+"error_code_prefix" = "Error code:";
+"error_timeout" = "The request timed out. Please check your network and try again";
+"error_connection_failed" = "Unable to establish a connection to the server. Please check your network and try again.";

--- a/Sources/UBFoundation/Resources/fr.lproj/Localizable.strings
+++ b/Sources/UBFoundation/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+"error_unexpected" = "Une erreur inattendue s'est produite.";
+"error_invalid_certificate_message" = "Connexion sécurisée au serveur impossible. Vérifiez ou désactivez votre VPN ou proxy, ou contrôlez si vous êtes connecté à un WLAN public.";
+"error_code_prefix" = "Code d‘erreur:";
+"error_timeout" = "La demande a expiré. Veuillez vérifier votre réseau et réessayer.";
+"error_connection_failed" = "Impossible d'établir une connexion au serveur. Veuillez vérifier votre réseau et réessayer.";

--- a/Sources/UBFoundation/Resources/it.lproj/Localizable.strings
+++ b/Sources/UBFoundation/Resources/it.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+"error_unexpected" = "Si è verificato un errore imprevisto.";
+"error_invalid_certificate_message" = "Impossibile stabilire una connessione sicura al server. Verifica o disattiva la tua rete VPN o il tuo proxy oppure controlla se sei connesso attraverso una WLAN pubblica.";
+"error_code_prefix" = "Codice d‘errore:";
+"error_timeout" = "La richiesta è scaduta. Si prega di controllare la rete e riprovare.";
+"error_connection_failed" = "Impossibile stabilire una connessione con il server. Si prega di controllare la rete e riprovare.";


### PR DESCRIPTION
This PR introduces dedicated error messages and codes for networking errors (instead of "Operation could not be finished")

Before:
![before](https://github.com/UbiqueInnovation/ubkit-ios/assets/35527968/032f9195-f3d6-4bcf-95c8-18d00353e87e)
After
![after2](https://github.com/UbiqueInnovation/ubkit-ios/assets/35527968/2c932f72-27fe-4c15-88ee-db7e24d24be0)
![after1](https://github.com/UbiqueInnovation/ubkit-ios/assets/35527968/c82bd7d1-3a93-43cb-b04e-9ea8a83fbaa7)
