### PR TITLE
dont check locationServicesEnabled()

### DIFF
--- a/Sources/UBLocation/UBLocationManager.swift
+++ b/Sources/UBLocation/UBLocationManager.swift
@@ -463,12 +463,6 @@ public class UBLocationManager: NSObject {
 
     /// :nodoc:
     private func startLocationMonitoringWithoutChecks(_ delegate: UBLocationManagerDelegate) {
-        guard locationManager.locationServicesEnabled() else {
-            let requiredAuthorizationLevel = usage.minimumAuthorizationLevelRequired
-            delegate.locationManager(self, requiresPermission: requiredAuthorizationLevel)
-            return
-        }
-
         if usage.containsLocation {
             locationManager.startUpdatingLocation()
             startLocationTimer()

--- a/Sources/UBLocation/UBLocationManagerProtocol.swift
+++ b/Sources/UBLocation/UBLocationManagerProtocol.swift
@@ -51,6 +51,7 @@ extension CLLocationManager: UBLocationManagerProtocol {
         CLLocationManager.authorizationStatus()
     }
 
+    @available(*, deprecated, message: "locationServicesEnabled() not exposed to avoid use on main thread. Use CLLocationManager.locationServicesEnabled() directly if needed.")
     public func locationServicesEnabled() -> Bool {
         CLLocationManager.locationServicesEnabled()
     }


### PR DESCRIPTION
So wie ich die Doku verstehe, müssen wir das gar nicht machen und können uns die slow-responsive-message (+lags?) sparen