### PR TITLE
use github runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build & Test
 
 env:
-  XCODE_VERSION: "Xcode_14.2.0"
+  XCODE_VERSION: "Xcode_15.0"
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 jobs:
   build-and-test:
     name: Build & Tests
-    runs-on: ["self-hosted", "macOS"]
+    runs-on: macos-13
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -39,7 +39,7 @@ jobs:
 
   codequality:
     name: Codequality
-    runs-on: ["self-hosted", "macOS"]
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
For public repositories we use github hosted runners.