### PR TITLE
start capture sesion from background thread

### DIFF
--- a/Sources/UBQRScanner/QRScannerView.swift
+++ b/Sources/UBQRScanner/QRScannerView.swift
@@ -92,7 +92,9 @@ public class QRScannerView: UIView {
         setupCaptureSessionIfNeeded()
 
         if let c = captureSession, !c.isRunning {
-            c.startRunning()
+            DispatchQueue.global().async {
+                c.startRunning()
+            }
         }
     }
 


### PR DESCRIPTION
Ich habe jeweils eine Warnung von Xcode bekommen, dass man startRunning von einem Background Thread aufrufen sollte. Getestet mit ssimply Wallet.

@ubfelix 