### PR TITLE
Fix Cron Reload

### DIFF
--- a/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
+++ b/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
@@ -22,10 +22,10 @@ open class UBAutoRefreshCacheLogic: UBBaseCachingLogic {
     }
 
     /// Schedule a refresh cron job
-    private func scheduleRefreshCronJob(for task: UBURLDataTask, headers: [AnyHashable: Any], metrics: URLSessionTaskMetrics?) {
+    private func scheduleRefreshCronJob(for task: UBURLDataTask, headers: [AnyHashable: Any], metrics: URLSessionTaskMetrics?, referenceDate: Date? = nil) {
         cancelRefreshCronJob(for: task)
 
-        guard let nextRefreshDate = cachedResponseNextRefreshDate(headers, metrics: metrics) else {
+        guard let nextRefreshDate = cachedResponseNextRefreshDate(headers, metrics: metrics, referenceDate: referenceDate) else {
             return
         }
         // Schedule a new job
@@ -41,8 +41,8 @@ open class UBAutoRefreshCacheLogic: UBBaseCachingLogic {
     ///
     /// - Parameter allHeaderFields: The header fiealds.
     /// - Returns: The next refresh date. `nil` if no next refresh date is available
-    open func cachedResponseNextRefreshDate(_ allHeaderFields: [AnyHashable: Any], metrics: URLSessionTaskMetrics?) -> Date? {
-        guard let responseDateHeader = allHeaderFields.getCaseInsensitiveValue(key: dateHeaderFieldName) as? String, let responseDate = dateFormatter.date(from: responseDateHeader) else {
+    open func cachedResponseNextRefreshDate(_ allHeaderFields: [AnyHashable: Any], metrics: URLSessionTaskMetrics?, referenceDate: Date?) -> Date? {
+        guard let responseDateHeader = allHeaderFields.getCaseInsensitiveValue(key: dateHeaderFieldName) as? String, let responseDate = referenceDate ?? dateFormatter.date(from: responseDateHeader) else {
             // If we cannot find a date in the response header then we cannot comput the next refresh date
             return nil
         }

--- a/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
+++ b/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
@@ -86,7 +86,7 @@ open class UBAutoRefreshCacheLogic: UBBaseCachingLogic {
         if cachedURLResponse != nil ||
             response == UBStandardHTTPCode.notModified {
             // If there is a response or the response is not modified, reschedule the cron job
-            scheduleRefreshCronJob(for: ubDataTask, headers: response.allHeaderFields, metrics: metrics)
+            scheduleRefreshCronJob(for: ubDataTask, headers: response.allHeaderFields, metrics: metrics, referenceDate: Date())
         } else {
             // Otherwise cancel any current cron jobs
             cancelRefreshCronJob(for: ubDataTask)

--- a/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
+++ b/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
@@ -22,7 +22,7 @@ open class UBAutoRefreshCacheLogic: UBBaseCachingLogic {
     }
 
     /// Schedule a refresh cron job
-    private func scheduleRefreshCronJob(for task: UBURLDataTask, headers: [AnyHashable: Any], metrics: URLSessionTaskMetrics?, referenceDate: Date? = nil) {
+    private func scheduleRefreshCronJob(for task: UBURLDataTask, headers: [AnyHashable: Any], metrics: URLSessionTaskMetrics?, referenceDate: Date?) {
         cancelRefreshCronJob(for: task)
 
         guard let nextRefreshDate = cachedResponseNextRefreshDate(headers, metrics: metrics, referenceDate: referenceDate) else {
@@ -59,12 +59,19 @@ open class UBAutoRefreshCacheLogic: UBBaseCachingLogic {
             backoffInterval = 60
         }
 
+        let age: TimeInterval
+        if let ageHeader = allHeaderFields.getCaseInsensitiveValue(key: ageHeaderFieldName) as? String, let interval = TimeInterval(ageHeader) {
+            age = interval
+        } else {
+            age = 0
+        }
+
         // The backoff date is the response date added to the backoff interval
         let backoffDate: Date
         if let metrics = metrics, let date = metrics.transactionMetrics.last?.connectEndDate {
-            backoffDate = max(responseDate + backoffInterval, date + backoffInterval)
+            backoffDate = max(responseDate + age + backoffInterval, date + backoffInterval)
         } else {
-            backoffDate = responseDate + backoffInterval
+            backoffDate = responseDate + age + backoffInterval
         }
 
         // Return the date that is the most in the future.
@@ -103,6 +110,6 @@ open class UBAutoRefreshCacheLogic: UBBaseCachingLogic {
     /// :nodoc:
 
     override public func hasUsed(response: HTTPURLResponse, metrics: URLSessionTaskMetrics?, request _: URLRequest, dataTask: UBURLDataTask) {
-        scheduleRefreshCronJob(for: dataTask, headers: response.allHeaderFields, metrics: metrics)
+        scheduleRefreshCronJob(for: dataTask, headers: response.allHeaderFields, metrics: metrics, referenceDate: nil)
     }
 }

--- a/Tests/UBFoundationTests/Networking/ConcurrentNetworkTests.swift
+++ b/Tests/UBFoundationTests/Networking/ConcurrentNetworkTests.swift
@@ -150,8 +150,8 @@ private class MeteoAutoRefreshCacheLogic: UBAutoRefreshCacheLogic {
     }
 
     // scale relative time for faster unit test
-    override func cachedResponseNextRefreshDate(_ allHeaderFields: [AnyHashable: Any], metrics: URLSessionTaskMetrics?) -> Date? {
-        if let date = super.cachedResponseNextRefreshDate(allHeaderFields, metrics: metrics) {
+    override func cachedResponseNextRefreshDate(_ allHeaderFields: [AnyHashable: Any], metrics: URLSessionTaskMetrics?, referenceDate: Date?) -> Date? {
+        if let date = super.cachedResponseNextRefreshDate(allHeaderFields, metrics: metrics, referenceDate: referenceDate) {
             return Date(timeIntervalSinceNow: date.timeIntervalSinceNow * 0.01)
         } else {
             return nil

--- a/Tests/UBFoundationTests/Networking/TaskAutoRefreshLogicTests.swift
+++ b/Tests/UBFoundationTests/Networking/TaskAutoRefreshLogicTests.swift
@@ -11,155 +11,6 @@ import XCTest
 
 @available(iOS 15.0.0, *)
 class TaskAutoRefreshLogicTests: XCTestCase {
-    func testCaching() {
-        // Load Request with Meteo-specific headers to enable cache
-
-        let url = URL(string: "https://s3-eu-central-1.amazonaws.com/app-test-static-fra.meteoswiss-app.ch/v1/warnings_with_outlook_with_naturalhazards_de.json")!
-
-        let cache = MeteoAutoRefreshCacheLogic()
-        let conf = UBURLSessionConfiguration(cachingLogic: cache)
-        let c = URLCache(memoryCapacity: 1024 * 1024 * 4, diskCapacity: 1024 * 1024 * 10, diskPath: "meteo")
-        c.removeAllCachedResponses()
-        conf.sessionConfiguration.urlCache = c
-        let session = UBURLSession(configuration: conf)
-
-        let res = expectation(description: "res")
-        session.reset {
-            res.fulfill()
-        }
-        wait(for: [res], timeout: 10000)
-
-        // load request to fill cache
-
-        var dataTask: UBURLDataTask? = UBURLDataTask(url: url, session: session)
-
-        let ex = expectation(description: "s")
-        ex.assertForOverFulfill = false
-        dataTask?.addCompletionHandler(decoder: .passthrough) { _, _, _, _ in
-            ex.fulfill()
-            dataTask?.cancel() // make sure that cron doesn't trigger
-            dataTask = nil
-        }
-        dataTask?.start()
-        wait(for: [ex], timeout: 10000)
-
-        dataTask?.cancel() // make sure that cron doesn't trigger
-        dataTask = nil
-
-        sleep(5)
-
-        // load request again
-
-        let dataTask2 = UBURLDataTask(url: url, session: session)
-
-        let ex2 = expectation(description: "s2")
-        dataTask2.addCompletionHandler(decoder: .passthrough) { _, _, info, _ in
-
-            XCTAssert(info != nil)
-            XCTAssert(info!.cacheHit)
-
-            ex2.fulfill()
-        }
-        dataTask2.start()
-        wait(for: [ex2], timeout: 10000)
-    }
-
-    func testCachingWithoutCacheControl() {
-        // Request with cron headers should cache even if no default cache control is set
-
-        let url = URL(string: "https://s3-eu-central-1.amazonaws.com/app-test-static-fra.meteoswiss-app.ch/v1/animation_overview.json")!
-
-        let cache = MeteoAutoRefreshCacheLogic()
-        let conf = UBURLSessionConfiguration(cachingLogic: cache)
-        let c = URLCache(memoryCapacity: 1024 * 1024 * 4, diskCapacity: 1024 * 1024 * 10, diskPath: "meteo")
-        conf.sessionConfiguration.urlCache = c
-        let session = UBURLSession(configuration: conf)
-
-        let res = expectation(description: "res")
-        session.reset {
-            res.fulfill()
-        }
-        wait(for: [res], timeout: 10000)
-
-        // load request to fill cache
-
-        let dataTask = UBURLDataTask(url: url, session: session)
-
-        let ex = expectation(description: "s")
-        dataTask.addCompletionHandler(decoder: .passthrough) { _, _, _, _ in
-
-            ex.fulfill()
-        }
-        dataTask.start()
-        wait(for: [ex], timeout: 10000)
-
-        // load request again
-
-        let dataTask2 = UBURLDataTask(url: url, session: session)
-
-        let ex2 = expectation(description: "s2")
-        dataTask2.addCompletionHandler(decoder: .passthrough) { _, _, info, _ in
-
-            XCTAssert(info != nil)
-            XCTAssert(info!.cacheHit)
-
-            ex2.fulfill()
-        }
-        dataTask2.start()
-        wait(for: [ex2], timeout: 10000)
-    }
-
-    func testRegaCaching() {
-        // Load Request with Meteo-specific headers to enable cache
-
-        let url = URL(string: "https://p-aps-regaws.azurewebsites.net/v1/webcam_overview.json")!
-
-        let cache = RegaAutoRefreshCacheLogic()
-        let conf = UBURLSessionConfiguration(cachingLogic: cache)
-        let c = URLCache(memoryCapacity: 1024 * 1024 * 4, diskCapacity: 1024 * 1024 * 10, diskPath: "meteo")
-        conf.sessionConfiguration.urlCache = c
-        let session = UBURLSession(configuration: conf)
-
-        let res = expectation(description: "res")
-        session.reset {
-            res.fulfill()
-        }
-        wait(for: [res], timeout: 10000)
-
-        // load request to fill cache
-
-        let dataTask = UBURLDataTask(url: url, session: session)
-
-        let ex = expectation(description: "s")
-        dataTask.addCompletionHandler(decoder: .passthrough) { _, _, _, _ in
-
-            ex.fulfill()
-        }
-        dataTask.start()
-        wait(for: [ex], timeout: 10000)
-
-        // load request again
-
-        let dataTask2 = UBURLDataTask(url: url, session: session)
-
-        let ex2 = expectation(description: "s2")
-        dataTask2.addCompletionHandler(decoder: .passthrough) { _, _, info, _ in
-
-            XCTAssert(info != nil)
-            XCTAssert(info!.cacheHit)
-
-            ex2.fulfill()
-        }
-
-        let ex3 = expectation(description: "s3")
-        dataTask2.addCompletionHandler(decoder: .passthrough) { _, _, _, _ in
-
-            ex3.fulfill()
-        }
-
-        dataTask2.start()
-        wait(for: [ex2, ex3], timeout: 10000)
-    }
 
     func testNoCacheHeaders() {
         // Load Request with default headers and no cache
@@ -196,29 +47,14 @@ class TaskAutoRefreshLogicTests: XCTestCase {
         let ex2 = expectation(description: "s2")
         dataTask2.addCompletionHandler(decoder: .passthrough) { _, _, info, _ in
 
-            XCTAssert(info != nil)
-            XCTAssertFalse(info!.cacheHit)
+            if let info {
+                XCTAssertFalse(info.cacheHit)
+            }
             ex2.fulfill()
         }
 
         dataTask2.start()
         wait(for: [ex2], timeout: 10000)
-    }
-
-    func testCacheModifier() {
-        startTasks(session: Networking.sharedSession, secondShouldCache: false)
-
-        let cache = SwisstopoMapAutorefreshCacheLogic()
-        let conf = UBURLSessionConfiguration(cachingLogic: cache)
-        let session = UBURLSession(configuration: conf)
-
-        let res = expectation(description: "res")
-        session.reset {
-            res.fulfill()
-        }
-        wait(for: [res], timeout: 10000)
-
-        startTasks(session: session, secondShouldCache: true)
     }
 
     private func startTasks(session: UBURLSession, secondShouldCache: Bool) {
@@ -303,45 +139,6 @@ class TaskAutoRefreshLogicTests: XCTestCase {
         wait(for: [ex2], timeout: 10000)
     }
 
-    func testAutoRefresh() {
-        // Load Request with default headers and no cache
-
-        let url = URL(string: "https://s3-eu-central-1.amazonaws.com/app-test-static-fra.meteoswiss-app.ch/v1/warnings_with_outlook_with_naturalhazards_de.json")!
-
-        // load request and wait for two responses
-
-        let cache = MeteoAutoRefreshCacheLogic()
-        let conf = UBURLSessionConfiguration(cachingLogic: cache)
-        let c = URLCache(memoryCapacity: 1024 * 1024 * 4, diskCapacity: 1024 * 1024 * 10, diskPath: "meteo")
-        c.removeAllCachedResponses()
-        conf.sessionConfiguration.urlCache = c
-        let session = UBURLSession(configuration: conf)
-
-        let res = expectation(description: "res")
-        session.reset {
-            res.fulfill()
-        }
-        wait(for: [res], timeout: 10000)
-
-        let dataTask = UBURLDataTask(url: url, session: session)
-
-        let ex1 = expectation(description: "s")
-        let ex2 = expectation(description: "s2")
-
-        dataTask.addCompletionHandler(decoder: .passthrough) { _, _, info, _ in
-
-            XCTAssert(info != nil)
-
-            if info!.refresh {
-                ex1.fulfill()
-            } else {
-                ex2.fulfill()
-            }
-        }
-        dataTask.start()
-        wait(for: [ex1, ex2], timeout: 10000)
-    }
-
     func testCacheHeaderUpdate() {
         // Load Request that changes cached header
         let url = URL(string: "https://example.com/file.json")!
@@ -358,8 +155,7 @@ class TaskAutoRefreshLogicTests: XCTestCase {
             LocalServer.pauseLocalServer()
         }
 
-        let cache = SwisstopoVectorRefreshCacheLogic()
-        let conf = UBURLSessionConfiguration(cachingLogic: cache)
+        let conf = UBURLSessionConfiguration()
         conf.sessionConfiguration.urlCache = URLCache(memoryCapacity: 1024 * 1024 * 4, diskCapacity: 1024 * 1024 * 10, diskPath: nil)
         conf.sessionConfiguration.protocolClasses = [LocalServerURLProtocol.self]
         let session = UBURLSession(configuration: conf)
@@ -424,42 +220,6 @@ class TaskAutoRefreshLogicTests: XCTestCase {
         XCTAssert(info4!.cacheHit) // in cache again
     }
 
-    func testEmptyCache() {
-        // Ensure that request with empty body is cached too
-
-        let url = URL(string: "https://dev-static.swisstopo-app.ch/v10/stations/22/417/158.pbf")!
-
-        let cache = SwisstopoVectorRefreshCacheLogic()
-        let conf = UBURLSessionConfiguration(cachingLogic: cache)
-        let c = URLCache(memoryCapacity: 1024 * 1024 * 4, diskCapacity: 1024 * 1024 * 10, diskPath: "meteo")
-        c.removeAllCachedResponses()
-        conf.sessionConfiguration.urlCache = c
-        let session = UBURLSession(configuration: conf)
-
-        let res = expectation(description: "res")
-        session.reset {
-            res.fulfill()
-        }
-        wait(for: [res], timeout: 10000)
-
-        // load request to fill cache
-
-        let dataTask = UBURLDataTask(url: url, session: session)
-
-        dataTask.startSynchronous(decoder: .passthrough)
-
-        // load request again
-
-        let dataTask2 = UBURLDataTask(url: url, session: session)
-        dataTask2.addStateTransitionObserver { _, to, _ in
-            XCTAssert(to != .fetching) // never make the request
-        }
-        let (_, _, info, _) = dataTask2.startSynchronous(decoder: .passthrough)
-
-        XCTAssert(info != nil)
-        XCTAssert(info!.cacheHit)
-    }
-
     func testNoLanguageCaching() {
         // Load Request with Meteo-specific headers to enable cache
 
@@ -522,49 +282,6 @@ class TaskAutoRefreshLogicTests: XCTestCase {
         }
         dataTask3.start()
         wait(for: [ex3], timeout: 10000)
-    }
-}
-
-private class MeteoAutoRefreshCacheLogic: UBAutoRefreshCacheLogic {
-    // scale relative time for faster unit test
-    override func cachedResponseNextRefreshDate(_ allHeaderFields: [AnyHashable: Any], metrics: URLSessionTaskMetrics?) -> Date? {
-        if let date = super.cachedResponseNextRefreshDate(allHeaderFields, metrics: metrics) {
-            return Date(timeIntervalSinceNow: date.timeIntervalSinceNow * 0.01)
-        } else {
-            return nil
-        }
-    }
-}
-
-class RegaAutoRefreshCacheLogic: UBAutoRefreshCacheLogic {
-    // scale relative time for faster unit test
-    override func cachedResponseNextRefreshDate(_ allHeaderFields: [AnyHashable: Any], metrics: URLSessionTaskMetrics?) -> Date? {
-        if let date = super.cachedResponseNextRefreshDate(allHeaderFields, metrics: metrics) {
-            return Date(timeIntervalSinceNow: date.timeIntervalSinceNow * 0.01)
-        } else {
-            return nil
-        }
-    }
-}
-
-class SwisstopoVectorRefreshCacheLogic: UBAutoRefreshCacheLogic {
-    // scale relative time for faster unit test
-    override func cachedResponseNextRefreshDate(_ allHeaderFields: [AnyHashable: Any], metrics: URLSessionTaskMetrics?) -> Date? {
-        if let date = super.cachedResponseNextRefreshDate(allHeaderFields, metrics: metrics) {
-            return Date(timeIntervalSinceNow: date.timeIntervalSinceNow * 0.1)
-        } else {
-            return nil
-        }
-    }
-}
-
-class SwisstopoMapAutorefreshCacheLogic: UBAutoRefreshCacheLogic {
-    override func shouldWriteToCache(allowed _: Bool, data _: Data?, response _: HTTPURLResponse) -> Bool {
-        true
-    }
-
-    override func modifyCacheResult(proposed _: UBCacheResult, possible: UBCacheResult, reason _: UBBaseCachingLogic.CacheDecisionReason) -> UBCacheResult {
-        possible
     }
 }
 

--- a/Tests/UBFoundationTests/Networking/UBSessionTests.swift
+++ b/Tests/UBFoundationTests/Networking/UBSessionTests.swift
@@ -26,59 +26,6 @@ class UBSessionTests: XCTestCase {
         return testBundle
     }()
 
-    func testNotSuccessStatusCode() {
-        let ex = expectation(description: "s")
-        let url = URL(string: "https://limmat.ubique.ch/sandbox/status/404")!
-        let dataTask = UBURLDataTask(url: url)
-        dataTask.addCompletionHandler(decoder: .passthrough) { result, _, _, _ in
-            switch result {
-                case .success:
-                    XCTFail()
-                case .failure:
-                    break
-            }
-            ex.fulfill()
-        }
-        dataTask.start()
-        waitForExpectations(timeout: 10, handler: nil)
-    }
-
-    func testSuccessStatusCode() {
-        let ex = expectation(description: "s")
-        let url = URL(string: "https://limmat.ubique.ch/sandbox/status/200")!
-        let dataTask = UBURLDataTask(url: url)
-        dataTask.addCompletionHandler(decoder: .passthrough) { result, _, _, _ in
-            switch result {
-                case .success:
-                    break
-                case .failure:
-                    XCTFail()
-            }
-            ex.fulfill()
-        }
-        dataTask.start()
-        waitForExpectations(timeout: 10, handler: nil)
-    }
-
-    func testNoRedirection() {
-        let ex = expectation(description: "s")
-        let url = URL(string: "https://limmat.ubique.ch/sandbox/status/302")!
-        let configuration = UBURLSessionConfiguration(allowRedirections: false)
-        let session = UBURLSession(configuration: configuration)
-        let dataTask = UBURLDataTask(url: url, session: session)
-        dataTask.addCompletionHandler(decoder: .passthrough) { result, _, _, _ in
-            switch result {
-                case .success:
-                    XCTFail()
-                case let .failure(error):
-                    XCTAssertEqual(error, UBNetworkingError.internal(.requestRedirected))
-            }
-            ex.fulfill()
-        }
-        dataTask.start()
-        waitForExpectations(timeout: 10, handler: nil)
-    }
-
     func testRedirection() {
         let ex = expectation(description: "s")
         let url = URL(string: "http://ubique.ch")!
@@ -151,7 +98,7 @@ class UBSessionTests: XCTestCase {
                 case .success:
                     XCTFail("Certificate Pinning should have failed")
                 case let .failure(error):
-                    XCTAssertEqual(error, UBNetworkingError.certificateValidationFailed)
+                    XCTAssertEqual(error, UBNetworkingError.certificateValidationFailed(nil))
             }
             ex.fulfill()
         }
@@ -171,7 +118,7 @@ class UBSessionTests: XCTestCase {
                 case .success:
                     XCTFail("Certificate Pinning should have failed")
                 case let .failure(error):
-                    XCTAssertEqual(error, UBNetworkingError.certificateValidationFailed)
+                    XCTAssertEqual(error, UBNetworkingError.certificateValidationFailed(nil))
             }
             ex.fulfill()
         }
@@ -191,7 +138,7 @@ class UBSessionTests: XCTestCase {
                 case .success:
                     XCTFail("Certificate Pinning should have failed")
                 case let .failure(error):
-                    XCTAssertEqual(error, UBNetworkingError.certificateValidationFailed)
+                    XCTAssertEqual(error, UBNetworkingError.certificateValidationFailed(nil))
             }
             ex.fulfill()
         }
@@ -211,7 +158,7 @@ class UBSessionTests: XCTestCase {
                 case .success:
                     XCTFail("Certificate Pinning should have failed")
                 case let .failure(error):
-                    XCTAssertEqual(error, UBNetworkingError.certificateValidationFailed)
+                    XCTAssertEqual(error, UBNetworkingError.certificateValidationFailed(nil))
             }
             ex.fulfill()
         }


### PR DESCRIPTION
If cron refresh is scheduled by cached response, use "now" as reference for adding the backoff interval, not date in response headers. 

Otherwise, constant reloads might happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced cache refresh logic with the ability to specify a reference date for scheduling cache updates.

- **Bug Fixes**
  - Fixed an issue where the cache refresh scheduling did not account for a specific reference time.

- **Tests**
  - Removed outdated test methods and classes related to caching logic to align with the updated caching strategy.
  - Updated test cases to reflect changes in error handling and cache refresh logic.

- **Documentation**
  - Updated method signatures in documentation to reflect the addition of the `referenceDate` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->