### PR TITLE
Send E-Tag with Reload Requests

### DIFF
--- a/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
+++ b/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
@@ -30,7 +30,7 @@ open class UBAutoRefreshCacheLogic: UBBaseCachingLogic {
         }
         // Schedule a new job
         let job = UBCronJob(fireAt: nextRefreshDate, qos: qos) { [weak task] in
-            task?.start(flags: [.systemTriggered, .ignoreCache])
+            task?.start(flags: [.systemTriggered, .refresh])
         }
         refreshJobsAccess.sync {
             refreshJobs.setObject(job, forKey: task)

--- a/Sources/UBFoundation/Networking/CachingLogic.swift
+++ b/Sources/UBFoundation/Networking/CachingLogic.swift
@@ -17,6 +17,22 @@ public enum UBCacheResult {
     case expired(cachedResponse: CachedURLResponse, reloadHeaders: [String: String], metrics: URLSessionTaskMetrics?)
     /// Cached data found and is valid
     case hit(cachedResponse: CachedURLResponse, reloadHeaders: [String: String], metrics: URLSessionTaskMetrics?)
+
+    var reloadHeaders: [String: String] {
+        switch self {
+            case .miss: return [:]
+            case .expired(cachedResponse: _, reloadHeaders: let h, metrics: _): return h
+            case .hit(cachedResponse: _, reloadHeaders: let h, metrics: _): return h
+        }
+    }
+
+    var cachedResponse: CachedURLResponse? {
+        switch self {
+            case .miss: return nil
+            case .expired(cachedResponse: let r, reloadHeaders: _, metrics: _): return r
+            case .hit(cachedResponse: let r, reloadHeaders: _, metrics: _): return r
+        }
+    }
 }
 
 /// A caching logic object can provide decision when comes to requests and response that needs caching

--- a/Sources/UBFoundation/Networking/UBURLDataTask.swift
+++ b/Sources/UBFoundation/Networking/UBURLDataTask.swift
@@ -38,6 +38,8 @@ public final class UBURLDataTask: UBURLSessionTask, CustomStringConvertible, Cus
         public static let systemTriggered = Flags(rawValue: 1 << 1)
         /// If the task is running synchronous
         public static let synchronous = Flags(rawValue: 1 << 2)
+        /// The request reloads existing data and will always load from network
+        public static let refresh = Flags(rawValue: 1 << 3)
     }
 
     public private(set) var flags: Flags = []
@@ -159,6 +161,7 @@ public final class UBURLDataTask: UBURLSessionTask, CustomStringConvertible, Cus
         } else {
             flags.remove(.ignoreCache)
         }
+        flags.remove(.refresh)
         start(flags: flags)
     }
 

--- a/Sources/UBFoundation/Networking/UBURLSession+Delegate.swift
+++ b/Sources/UBFoundation/Networking/UBURLSession+Delegate.swift
@@ -77,9 +77,9 @@ class UBURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDele
 
         guard let response = collectedData.response as? HTTPURLResponse else {
             #if os(watchOS)
-                let info = UBNetworkingTaskInfo(cacheHit: false, refresh: ubDataTask.flags.contains(.ignoreCache))
+                let info = UBNetworkingTaskInfo(cacheHit: false, refresh: ubDataTask.flags.contains(.refresh))
             #else
-                let info = UBNetworkingTaskInfo(metrics: collectedData.metrics, cacheHit: false, refresh: ubDataTask.flags.contains(.ignoreCache))
+                let info = UBNetworkingTaskInfo(metrics: collectedData.metrics, cacheHit: false, refresh: ubDataTask.flags.contains(.refresh))
             #endif
             ubDataTask.dataTaskCompleted(data: collectedData.data, response: nil, error: collectedData.error ?? error, info: info)
             return
@@ -102,9 +102,9 @@ class UBURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDele
         // If not modified return the cached data
         if response.statusCode == UBStandardHTTPCode.notModified, let cached = collectedData.cached {
             #if os(watchOS)
-                let info = UBNetworkingTaskInfo(cacheHit: true, refresh: ubDataTask.flags.contains(.ignoreCache))
+                let info = UBNetworkingTaskInfo(cacheHit: true, refresh: ubDataTask.flags.contains(.refresh))
             #else
-                let info = UBNetworkingTaskInfo(metrics: collectedData.metrics, cacheHit: true, refresh: ubDataTask.flags.contains(.ignoreCache))
+                let info = UBNetworkingTaskInfo(metrics: collectedData.metrics, cacheHit: true, refresh: ubDataTask.flags.contains(.refresh))
             #endif
 
             // Update the cache if needed
@@ -128,18 +128,18 @@ class UBURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDele
                 responseError = UBInternalNetworkingError.requestFailed(httpStatusCode: response.statusCode)
             }
             #if os(watchOS)
-                let info = UBNetworkingTaskInfo(cacheHit: false, refresh: ubDataTask.flags.contains(.ignoreCache))
+                let info = UBNetworkingTaskInfo(cacheHit: false, refresh: ubDataTask.flags.contains(.refresh))
             #else
-                let info = UBNetworkingTaskInfo(metrics: collectedData.metrics, cacheHit: false, refresh: ubDataTask.flags.contains(.ignoreCache))
+                let info = UBNetworkingTaskInfo(metrics: collectedData.metrics, cacheHit: false, refresh: ubDataTask.flags.contains(.refresh))
             #endif
             ubDataTask.dataTaskCompleted(data: collectedData.data, response: response, error: responseError, info: info)
             return
         }
 
         #if os(watchOS)
-            let info = UBNetworkingTaskInfo(cacheHit: false, refresh: ubDataTask.flags.contains(.ignoreCache))
+            let info = UBNetworkingTaskInfo(cacheHit: false, refresh: ubDataTask.flags.contains(.refresh))
         #else
-            let info = UBNetworkingTaskInfo(metrics: collectedData.metrics, cacheHit: false, refresh: ubDataTask.flags.contains(.ignoreCache))
+            let info = UBNetworkingTaskInfo(metrics: collectedData.metrics, cacheHit: false, refresh: ubDataTask.flags.contains(.refresh))
         #endif
         ubDataTask.dataTaskCompleted(data: collectedData.data, response: response, error: collectedData.error ?? error, info: info)
 

--- a/Sources/UBFoundation/Networking/UBURLSession.swift
+++ b/Sources/UBFoundation/Networking/UBURLSession.swift
@@ -51,13 +51,16 @@ public class UBURLSession: UBDataTaskURLSession {
         guard let cacheResult else {
             return createTask(request.getRequest())
         }
-
-        guard owner.flags.contains(.ignoreCache) == false else {
+        
+        if owner.flags.contains(.refresh) {
             var reloadRequest = request.getRequest()
             for header in cacheResult.reloadHeaders {
                 reloadRequest.setValue(header.value, forHTTPHeaderField: header.key)
             }
             return createTask(reloadRequest, cachedResponse: cacheResult.cachedResponse)
+        }
+        else if owner.flags.contains(.ignoreCache) {
+            return createTask(request.getRequest(), cachedResponse: nil)
         }
 
         switch (urlSession.configuration.requestCachePolicy, cacheResult) {


### PR DESCRIPTION
Neu werden die vorgeschlagenen Request-Headers auch bei Requests mit ignoreCache-Flag gesendet. Dies ist nötig, damit der E-Tag nicht verloren geht. 

Mögliche alternative Lösung: Zwei Varianten vom ignoreCache-Flag: 
- Flag 1: Wie jetzt umgesetzt: Cache wird semi-ignoriert, d.h. Request geht raus, aber bei 302 wird die Cache-Response trotzdem verwendet. Dieses Flag wäre für Cron-Reloads das richtige.
- Flag 2: Zusätzlich reallyIgnoreCache, bei dem nicht mal der E-Tag aus dem Cache an den Server gesendet wird.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced caching logic with new properties for improved data retrieval and management.
  - Introduced a 'refresh' option to ensure data is always loaded from the network when required.

- **Improvements**
  - Updated task creation process to better handle caching scenarios and user-defined flags.
  - Refined internal logic for determining when to refresh data, aligning with the new 'refresh' flag.

- **Documentation**
  - Updated documentation to reflect changes in caching behavior and flag usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->