### PR TITLE
Add API to catch parsing errors

### DIFF
--- a/Sources/UBDevTools/CacheDevTools.swift
+++ b/Sources/UBDevTools/CacheDevTools.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class CacheDevTools {
+enum CacheDevTools {
     public static var caches: [(id: String, cache: URLCache)] {
         [(id: "Shared", cache: URLCache.shared)] + additionalCaches
     }

--- a/Sources/UBDevTools/UserDefaultsDevTools.swift
+++ b/Sources/UBDevTools/UserDefaultsDevTools.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class UserDefaultsDevTools {
+enum UserDefaultsDevTools {
     static var sharedUserDefaults: UserDefaults?
 
     static func clearUserDefaults(_ defaults: UserDefaults) {

--- a/Sources/UBFoundation/Globals/GlobalNetworking.swift
+++ b/Sources/UBFoundation/Globals/GlobalNetworking.swift
@@ -32,6 +32,11 @@ public enum Networking {
         return global.addStateObserver(block)
     }
 
+    public static func addTaskCreationObserver(_ block: @escaping (UBURLDataTask) -> Void) {
+        globalActivityTracking = true
+        global.addTaskCreationObserver(block)
+    }
+
     /// Adds a task for the global network activity.
     ///
     /// - Parameter task: The task to add.

--- a/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
+++ b/Sources/UBFoundation/Networking/AutoRefreshCacheLogic.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 
 @available(iOS 14.0, watchOS 7.0, *)
-fileprivate struct Log {
+private enum Log {
     static let logger = Logger(subsystem: "UBKit", category: "AutoRefreshCacheLogic")
 }
 
@@ -47,8 +47,7 @@ open class UBAutoRefreshCacheLogic: UBBaseCachingLogic {
             if #available(iOS 14.0, watchOS 7.0, *) {
                 if let task {
                     Log.logger.trace("Start cron refresh for task \(task)")
-                }
-                else {
+                } else {
                     Log.logger.trace("Not start cron refresh, task doesn't exist anymore.")
                 }
             }

--- a/Sources/UBFoundation/Networking/CachingLogic.swift
+++ b/Sources/UBFoundation/Networking/CachingLogic.swift
@@ -37,7 +37,6 @@ public enum UBCacheResult {
 
 /// A caching logic object can provide decision when comes to requests and response that needs caching
 public protocol UBCachingLogic {
-
     /// Modify the request before starting
     /// Allows to change the cache policy
     func prepareRequest(_ request: inout URLRequest)

--- a/Sources/UBFoundation/Networking/Networking+Error.swift
+++ b/Sources/UBFoundation/Networking/Networking+Error.swift
@@ -118,27 +118,27 @@ extension UBNetworkingError: UBCodedError {
     }
 }
 
-extension UBNetworkingError {
-    public var errorDescription: String? {
+public extension UBNetworkingError {
+    var errorDescription: String? {
         switch self {
-        case .notConnected:
-            return NSLocalizedString("error_timeout", bundle: Bundle.module, comment: "Connection to the server failed")
-        case .timedOut:
-            return NSLocalizedString("error_timeout", bundle: Bundle.module, comment: "The request timed out")
-        case .certificateValidationFailed: 
-            return NSLocalizedString("error_invalid_certificate_message", bundle: Bundle.module, comment: "Validation of TLS certificate failed")
-        default: 
-            return NSLocalizedString("error_unexpected", bundle: Bundle.module, comment: "Generic unexpected error message")
+            case .notConnected:
+                return NSLocalizedString("error_timeout", bundle: Bundle.module, comment: "Connection to the server failed")
+            case .timedOut:
+                return NSLocalizedString("error_timeout", bundle: Bundle.module, comment: "The request timed out")
+            case .certificateValidationFailed:
+                return NSLocalizedString("error_invalid_certificate_message", bundle: Bundle.module, comment: "Validation of TLS certificate failed")
+            default:
+                return NSLocalizedString("error_unexpected", bundle: Bundle.module, comment: "Generic unexpected error message")
         }
     }
 
-    public var localizedDescription: String {
+    var localizedDescription: String {
         var errorMessage = NSLocalizedString("error_unexpected", bundle: Bundle.module, comment: "Generic unexpected error message")
         if let description = errorDescription {
             errorMessage = description
         }
         let errorCodePrefix = NSLocalizedString("error_code_prefix", bundle: Bundle.module, comment: "Prefix of error code")
-        
+
         return "\(errorMessage)\n\n\(errorCodePrefix) \(errorCode)"
     }
 }

--- a/Sources/UBFoundation/Networking/UBURLDataTask+Decoder.swift
+++ b/Sources/UBFoundation/Networking/UBURLDataTask+Decoder.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 #endif
 
 /// An object that can decode data into the desired type
@@ -100,28 +100,32 @@ public extension UBURLDataTaskDecoder where T: Decodable {
         UBHTTPJSONDecoder(decoder: decoder)
     }
 
+    static func json(_ type: T.Type, decoder: JSONDecoder = JSONDecoder()) -> UBURLDataTaskDecoder {
+        UBHTTPJSONDecoder(decoder: decoder)
+    }
+
     static func json(dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .deferredToDate, dataDecodingStrategy: JSONDecoder.DataDecodingStrategy = .base64) -> UBURLDataTaskDecoder {
         UBHTTPJSONDecoder(dateDecodingStrategy: dateDecodingStrategy, dataDecodingStrategy: dataDecodingStrategy)
     }
 }
 
 #if canImport(UIKit)
-public class UBImageDecoder: UBURLDataTaskDecoder<UIImage> {
-    /// Initializes the decoder
-    ///
-    /// - Parameter scale: Use 2 or 3 to create images with more pixels than points
-    public init(scale: Double = 1) {
-        super.init { data, _ -> UIImage in
-            guard let image = UIImage(data: data, scale: scale) else {
-                throw UBInternalNetworkingError.couldNotDecodeBody
+    public class UBImageDecoder: UBURLDataTaskDecoder<UIImage> {
+        /// Initializes the decoder
+        ///
+        /// - Parameter scale: Use 2 or 3 to create images with more pixels than points
+        public init(scale: Double = 1) {
+            super.init { data, _ -> UIImage in
+                guard let image = UIImage(data: data, scale: scale) else {
+                    throw UBInternalNetworkingError.couldNotDecodeBody
+                }
+                return image
             }
-            return image
         }
     }
-}
 
-public extension UBURLDataTaskDecoder where T == UIImage {
-    static let image = UBImageDecoder()
-}
+    public extension UBURLDataTaskDecoder where T == UIImage {
+        static let image = UBImageDecoder()
+    }
 
 #endif

--- a/Sources/UBFoundation/Networking/UBURLSession.swift
+++ b/Sources/UBFoundation/Networking/UBURLSession.swift
@@ -53,15 +53,14 @@ public class UBURLSession: UBDataTaskURLSession {
         guard let cacheResult else {
             return createTask(request.getRequest())
         }
-        
+
         if owner.flags.contains(.refresh) {
             var reloadRequest = request.getRequest()
             for header in cacheResult.reloadHeaders {
                 reloadRequest.setValue(header.value, forHTTPHeaderField: header.key)
             }
             return createTask(reloadRequest, cachedResponse: cacheResult.cachedResponse)
-        }
-        else if owner.flags.contains(.ignoreCache) {
+        } else if owner.flags.contains(.ignoreCache) {
             return createTask(request.getRequest(), cachedResponse: nil)
         }
 

--- a/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
+++ b/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
@@ -10,8 +10,6 @@ import XCTest
 
 class PostCompletionTest: XCTestCase {
     func testPostCompletionSuccess() {
-
-
         let url = URL(string: "https://github.com/UbiqueInnovation/ubkit-ios")!
         var request = URLRequest(url: url)
         request.addValue("application/json", forHTTPHeaderField: "Accept")
@@ -48,8 +46,6 @@ class PostCompletionTest: XCTestCase {
     }
 
     func testPostCompletionError() {
-
-
         let url = URL(string: "https://github.com/UbiqueInnovation/ubkit-ios-not-existing")!
         var request = URLRequest(url: url)
         request.addValue("application/json", forHTTPHeaderField: "Accept")

--- a/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
+++ b/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
@@ -1,0 +1,87 @@
+//
+//  PostCompletionTest.swift
+//
+//
+//  Created by Nicolas Märki on 12.12.2023.
+//
+
+import UBFoundation
+import XCTest
+
+class PostCompletionTest: XCTestCase {
+    func testPostCompletionSuccess() {
+
+
+        let url = URL(string: "https://github.com/UbiqueInnovation/ubkit-ios")!
+        var request = URLRequest(url: url)
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+
+        let task = UBURLDataTask(request: request)
+
+        let exp = expectation(description: "post")
+        exp.expectedFulfillmentCount = 2
+        task.postCompletionHandler = { result in
+            switch result {
+                case .success:
+                    exp.fulfill()
+                default: break
+            }
+        }
+
+        struct Body: Decodable {
+            let title: String
+        }
+
+        let exp2 = expectation(description: "json")
+        task.addCompletionHandler(decoder: .json(Body.self)) { result, _, _, _ in
+            exp2.fulfill()
+        }
+
+        let exp3 = expectation(description: "string")
+        task.addCompletionHandler(decoder: .string) { result, _, _, _ in
+            exp3.fulfill()
+        }
+
+        task.start()
+
+        wait(for: [exp, exp2, exp3])
+    }
+
+    func testPostCompletionError() {
+
+
+        let url = URL(string: "https://github.com/UbiqueInnovation/ubkit-ios-not-existing")!
+        var request = URLRequest(url: url)
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+
+        let task = UBURLDataTask(request: request)
+
+        let exp = expectation(description: "post")
+        exp.expectedFulfillmentCount = 2
+        task.postCompletionHandler = { result in
+            switch result {
+                case .failure(.internal(.requestFailed(httpStatusCode: 404))):
+                    exp.fulfill()
+                default: break
+            }
+        }
+
+        struct Body: Decodable {
+            let title: String
+        }
+
+        let exp2 = expectation(description: "json")
+        task.addCompletionHandler(decoder: .json(Body.self)) { result, _, _, _ in
+            exp2.fulfill()
+        }
+
+        let exp3 = expectation(description: "string")
+        task.addCompletionHandler(decoder: .string) { result, _, _, _ in
+            exp3.fulfill()
+        }
+
+        task.start()
+
+        wait(for: [exp, exp2, exp3])
+    }
+}

--- a/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
+++ b/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
@@ -31,12 +31,26 @@ class PostCompletionTest: XCTestCase {
         }
 
         let exp2 = expectation(description: "json")
-        task.addCompletionHandler(decoder: .json(Body.self)) { result, _, _, _ in
+        task.addCompletionHandler(decoder: .json(Body.self)) { result, response, _, _ in
+            switch result {
+                case .success:
+                    break
+                case let .failure(error):
+                    XCTFail(error.localizedDescription)
+            }
+            XCTAssertEqual(response?.statusCode.ub_standardHTTPCode, UBStandardHTTPCode.ok)
             exp2.fulfill()
         }
 
         let exp3 = expectation(description: "string")
-        task.addCompletionHandler(decoder: .string) { result, _, _, _ in
+        task.addCompletionHandler(decoder: .string) { result, response, _, _ in
+            switch result {
+                case .success:
+                    break
+                case let .failure(error):
+                    XCTFail(error.localizedDescription)
+            }
+            XCTAssertEqual(response?.statusCode.ub_standardHTTPCode, UBStandardHTTPCode.ok)
             exp3.fulfill()
         }
 
@@ -67,12 +81,26 @@ class PostCompletionTest: XCTestCase {
         }
 
         let exp2 = expectation(description: "json")
-        task.addCompletionHandler(decoder: .json(Body.self)) { result, _, _, _ in
+        task.addCompletionHandler(decoder: .json(Body.self)) { result, response, _, _ in
+            switch result {
+                case .success:
+                    break
+                case let .failure(error):
+                    XCTFail(error.localizedDescription)
+            }
+            XCTAssertEqual(response?.statusCode.ub_standardHTTPCode, UBStandardHTTPCode.notFound)
             exp2.fulfill()
         }
 
         let exp3 = expectation(description: "string")
-        task.addCompletionHandler(decoder: .string) { result, _, _, _ in
+        task.addCompletionHandler(decoder: .string) { result, response, _, _ in
+            switch result {
+                case .success:
+                    break
+                case let .failure(error):
+                    XCTFail(error.localizedDescription)
+            }
+            XCTAssertEqual(response?.statusCode.ub_standardHTTPCode, UBStandardHTTPCode.notFound)
             exp3.fulfill()
         }
 

--- a/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
+++ b/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
@@ -84,9 +84,9 @@ class PostCompletionTest: XCTestCase {
         task.addCompletionHandler(decoder: .json(Body.self)) { result, response, _, _ in
             switch result {
                 case .success:
+                    XCTFail()
+                case .failure(_):
                     break
-                case let .failure(error):
-                    XCTFail(error.localizedDescription)
             }
             XCTAssertEqual(response?.statusCode.ub_standardHTTPCode, UBStandardHTTPCode.notFound)
             exp2.fulfill()
@@ -96,9 +96,9 @@ class PostCompletionTest: XCTestCase {
         task.addCompletionHandler(decoder: .string) { result, response, _, _ in
             switch result {
                 case .success:
+                    XCTFail()
+                case .failure(_):
                     break
-                case let .failure(error):
-                    XCTFail(error.localizedDescription)
             }
             XCTAssertEqual(response?.statusCode.ub_standardHTTPCode, UBStandardHTTPCode.notFound)
             exp3.fulfill()

--- a/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
+++ b/Tests/UBFoundationTests/Networking/PostCompletionTest.swift
@@ -85,7 +85,7 @@ class PostCompletionTest: XCTestCase {
             switch result {
                 case .success:
                     XCTFail()
-                case .failure(_):
+                case .failure:
                     break
             }
             XCTAssertEqual(response?.statusCode.ub_standardHTTPCode, UBStandardHTTPCode.notFound)
@@ -97,7 +97,7 @@ class PostCompletionTest: XCTestCase {
             switch result {
                 case .success:
                     XCTFail()
-                case .failure(_):
+                case .failure:
                     break
             }
             XCTAssertEqual(response?.statusCode.ub_standardHTTPCode, UBStandardHTTPCode.notFound)

--- a/Tests/UBFoundationTests/Networking/TaskAutoRefreshLogicTests.swift
+++ b/Tests/UBFoundationTests/Networking/TaskAutoRefreshLogicTests.swift
@@ -11,7 +11,6 @@ import XCTest
 
 @available(iOS 15.0.0, *)
 class TaskAutoRefreshLogicTests: XCTestCase {
-
     func testNoCacheHeaders() {
         // Load Request with default headers and no cache
 

--- a/Tests/UBFoundationTests/Networking/TaskBaseCachingTests.swift
+++ b/Tests/UBFoundationTests/Networking/TaskBaseCachingTests.swift
@@ -8,34 +8,4 @@
 import UBFoundation
 import XCTest
 
-class BaseCachingTests: XCTestCase {
-    func testMethodChange() {
-        // Ensure that requests with different HTTP methods are not cached
-
-        let url = URL(string: "https://dev-static.swisstopo-app.ch/v10/stations/22/417/158.pbf")!
-
-        let configuration = UBURLSessionConfiguration()
-        configuration.sessionConfiguration.networkServiceType = .responsiveData
-        let session = UBURLSession(configuration: configuration)
-
-        let res = expectation(description: "res")
-        session.reset {
-            res.fulfill()
-        }
-        wait(for: [res], timeout: 10000)
-
-        // load request to fill cache
-        var request = UBURLRequest(url: url)
-        request.httpMethod = .head
-        let dataTask = UBURLDataTask(request: request)
-        dataTask.startSynchronous(decoder: .passthrough)
-
-        // load request again with different method
-        request.httpMethod = .get
-        let dataTask2 = UBURLDataTask(request: request)
-        let (_, _, info, _) = dataTask2.startSynchronous(decoder: .passthrough)
-
-        XCTAssert(info != nil)
-        XCTAssert(info!.cacheHit == false)
-    }
-}
+class BaseCachingTests: XCTestCase {}

--- a/Tests/UBFoundationTests/Networking/UBSessionTests.swift
+++ b/Tests/UBFoundationTests/Networking/UBSessionTests.swift
@@ -29,7 +29,7 @@ class UBSessionTests: XCTestCase {
     func testRedirection() {
         let ex = expectation(description: "s")
         let url = URL(string: "http://ubique.ch")!
-        let dataTask = UBURLDataTask(url: url, session: Networking.sharedLowPrioritySession)
+        let dataTask = UBURLDataTask(url: url, session: Networking.sharedSession)
         dataTask.addCompletionHandler(decoder: .passthrough) { result, response, _, _ in
             switch result {
                 case .success:

--- a/Tests/UBFoundationTests/Networking/UBSessionTests.swift
+++ b/Tests/UBFoundationTests/Networking/UBSessionTests.swift
@@ -41,7 +41,7 @@ class UBSessionTests: XCTestCase {
             ex.fulfill()
         }
         dataTask.start()
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 15, handler: nil)
     }
 
     func testURLValidationFailed() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,7 +7,7 @@ platform :ios do
       scan(
         package_path: ".",
         scheme: "UBKit-Package",
-        destination: "platform=iOS Simulator,name=iPhone 14 Pro",
+        device: "iPhone 15 Pro",
         result_bundle: true,
         output_directory: "./build/"
       )


### PR DESCRIPTION
Sind leider noch ein paar ältere Lint-Changes reingerutscht. Relevanter Change ist eigentlich der postCompletionHandler, mit dem man Errors unabhängig vom Parser catchen und loggen kann.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new observer function for tracking task creation in networking activities.
  - Added a new static function for JSON decoding in `UBURLDataTaskDecoder`.
  - Implemented a new post-completion handler pattern for network tasks.

- **Enhancements**
  - Updated the `UBURLDataTask` initializer to accept `URLRequest` for more flexibility.
  - Improved logging within the auto-refresh cache logic.

- **Bug Fixes**
  - Adjusted test device in Fastfile to "iPhone 15 Pro" for more up-to-date testing.

- **Refactor**
  - Changed `CacheDevTools` and `UserDefaultsDevTools` from classes to enums to prevent instantiation and clarify usage.
  - Refactored `UBImageDecoder` for better error handling and code clarity.

- **Tests**
  - Added new tests for post-completion handling in network tasks.
  - Modified timeout settings in `UBSessionTests` to ensure reliability.

- **Documentation**
  - Updated access control for `UBNetworkingError` to reflect internal usage.

- **Style**
  - Reformatted import statement for UIKit in `UBURLDataTask+Decoder.swift`.

- **Chores**
  - Removed redundant newline in `UBCachingLogic` protocol declaration.

- **Revert**
  - No reverts in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->