### PR TITLE
Only stop location updates if allowsBackgroundLocationUpdates is false

### DIFF
--- a/Sources/UBLocation/UBLocationManager.swift
+++ b/Sources/UBLocation/UBLocationManager.swift
@@ -305,10 +305,10 @@ public class UBLocationManager: NSObject {
     @objc private func appDidEnterBackground() {
         appIsInBackground = true
 
-        if allUsages.containsLocation, !allUsages.contains(.backgroundLocation) {
+        if allUsages.containsLocation, !allUsages.contains(.backgroundLocation), !allowsBackgroundLocationUpdates {
             locationManager.stopUpdatingLocation()
         }
-        if allUsages.containsHeading, !allUsages.contains(.backgroundHeading) {
+        if allUsages.containsHeading, !allUsages.contains(.backgroundHeading), !allowsBackgroundLocationUpdates {
             locationManager.stopUpdatingHeading()
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for handling location updates when the app enters the background, ensuring better compliance with the `allowsBackgroundLocationUpdates` setting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->