### PR TITLE
Adds Equatable to QRScannerError

### DIFF
--- a/Sources/UBQRScanner/QRScannerError.swift
+++ b/Sources/UBQRScanner/QRScannerError.swift
@@ -14,3 +14,20 @@ public enum QRScannerError: Error {
     case captureSessionError(Error?)
     case torchError(Error?)
 }
+
+extension QRScannerError: Equatable {
+     public static func == (lhs: QRScannerError, rhs: QRScannerError) -> Bool {
+         switch (lhs, rhs) {
+         case (.cameraPermissionDenied, .cameraPermissionDenied):
+             return true
+         case (.cameraPermissionRestricted, .cameraPermissionRestricted):
+             return true
+         case (.captureSessionError(let lhsError), .captureSessionError(let rhsError)):
+             return lhsError?.localizedDescription == rhsError?.localizedDescription
+         case (.torchError(let lhsError), .torchError(let rhsError)):
+             return lhsError?.localizedDescription == rhsError?.localizedDescription
+         default:
+             return false
+         }
+     }
+}


### PR DESCRIPTION
- Adds Equatable conformance
 - Swift 6 complete strict concurrency checking gives a warning if we want to conform to it ourselves outside the module