### PR TITLE
use value-type (struct) for TaskConfig

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build & Test
 
 env:
-  XCODE_VERSION: "Xcode_16.0"
+  XCVERSION: "16.0"
 
 on:
   push:
@@ -16,8 +16,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Switch to ${{ env.XCODE_VERSION }}
-        run: sudo xcode-select --switch /Applications/${{ env.XCODE_VERSION }}.app
-
+      - name: Switch to ${{ env.XCVERSION }}
+        run: sudo xcodes select ${{ env.XCVERSION }}
+        
       - name: Fastlane
         run: fastlane tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build & Test
 
 env:
-  XCVERSION: "16.0"
+  XCVERSION: "16.1"
 
 on:
   push:

--- a/Sources/UBFoundation/Networking/Concurrency/UBURLDataTask+Concurrency.swift
+++ b/Sources/UBFoundation/Networking/Concurrency/UBURLDataTask+Concurrency.swift
@@ -15,7 +15,7 @@ public extension UBURLDataTask {
 
     typealias ResultTuple<T> = (result: Result<T, UBNetworkingError>, metadata: UBURLDataTask.MetaData)
 
-    struct TaskConfig {
+    struct TaskConfig: Sendable {
         public init(requestModifiers: [UBURLRequestModifier] = [], requestInterceptor: UBURLRequestInterceptor? = nil, failureRecoveryStrategies: [UBNetworkingTaskRecoveryStrategy] = [], session: UBDataTaskURLSession? = nil) {
             self.requestModifiers = requestModifiers
             self.requestInterceptor = requestInterceptor

--- a/Sources/UBFoundation/Networking/Concurrency/UBURLDataTask+Concurrency.swift
+++ b/Sources/UBFoundation/Networking/Concurrency/UBURLDataTask+Concurrency.swift
@@ -15,7 +15,7 @@ public extension UBURLDataTask {
 
     typealias ResultTuple<T> = (result: Result<T, UBNetworkingError>, metadata: UBURLDataTask.MetaData)
 
-    class TaskConfig {
+    struct TaskConfig {
         public init(requestModifiers: [UBURLRequestModifier] = [], requestInterceptor: UBURLRequestInterceptor? = nil, failureRecoveryStrategies: [UBNetworkingTaskRecoveryStrategy] = [], session: UBDataTaskURLSession? = nil) {
             self.requestModifiers = requestModifiers
             self.requestInterceptor = requestInterceptor
@@ -28,28 +28,28 @@ public extension UBURLDataTask {
         public var failureRecoveryStrategies: [UBNetworkingTaskRecoveryStrategy] = []
         public var session: UBDataTaskURLSession?
 
-        @discardableResult
         public func with(requestModifier: UBURLRequestModifier) -> TaskConfig {
-            requestModifiers.append(requestModifier)
-            return self
+            var copy = self
+            copy.requestModifiers.append(requestModifier)
+            return copy
         }
 
-        @discardableResult
         public func with(requestInterceptor: UBURLRequestInterceptor) -> TaskConfig {
-            self.requestInterceptor = requestInterceptor
-            return self
+            var copy = self
+            copy.requestInterceptor = requestInterceptor
+            return copy
         }
 
-        @discardableResult
         public func with(failureRecoveryStrategy: UBNetworkingTaskRecoveryStrategy) -> TaskConfig {
-            failureRecoveryStrategies.append(failureRecoveryStrategy)
-            return self
+            var copy = self
+            copy.failureRecoveryStrategies.append(failureRecoveryStrategy)
+            return copy
         }
 
-        @discardableResult
         public func with(session: UBDataTaskURLSession) -> TaskConfig {
-            self.session = session
-            return self
+            var copy = self
+            copy.session = session
+            return copy
         }
     }
 

--- a/Sources/UBFoundation/Networking/UBURLRequestInterceptor.swift
+++ b/Sources/UBFoundation/Networking/UBURLRequestInterceptor.swift
@@ -40,7 +40,7 @@ public struct UBURLInterceptorResult {
 }
 
 /// A request interceptor is called before a HTTPDataTask starts. It can be used to intercept the networ call and directly return a Response
-public protocol UBURLRequestInterceptor {
+public protocol UBURLRequestInterceptor: Sendable {
     /// Intercepts the request before it will start.
     ///
     /// - Parameters:

--- a/Sources/UBFoundation/Networking/UBURLSession+Protocol.swift
+++ b/Sources/UBFoundation/Networking/UBURLSession+Protocol.swift
@@ -24,7 +24,7 @@ public protocol UBURLSessionProtocol {
 }
 
 /// A data task capable session
-public protocol UBDataTaskURLSession: UBURLSessionProtocol {
+public protocol UBDataTaskURLSession: UBURLSessionProtocol, Sendable {
     /// Creates a task that retrieves the contents of a URL based on the specified URL request object, and calls a handler upon completion.
     ///
     /// - Parameters:

--- a/Sources/UBFoundation/Networking/UBURLSession.swift
+++ b/Sources/UBFoundation/Networking/UBURLSession.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An object that coordinates a group of related network data transfer tasks.
-public final class UBURLSession: UBDataTaskURLSession, Sendable {
+public final class UBURLSession: UBDataTaskURLSession {
     /// The underlying session
     public let urlSession: URLSession
 

--- a/Tests/UBFoundationTests/Networking/Helpers/DataTaskSessionMock.swift
+++ b/Tests/UBFoundationTests/Networking/Helpers/DataTaskSessionMock.swift
@@ -8,7 +8,7 @@
 import Foundation
 @testable import UBFoundation
 
-class DataTaskSessionMock: UBDataTaskURLSession {
+class DataTaskSessionMock: UBDataTaskURLSession, @unchecked Sendable {
     private var _allTasks: [URLSessionTask] = []
     var dataTaskConfigurationBlock: (UBURLRequest) -> URLSessionDataTaskMock.Configuration
 
@@ -17,11 +17,11 @@ class DataTaskSessionMock: UBDataTaskURLSession {
     }
 
     required init(configuration _: URLSessionConfiguration) {
-        fatalError("Not emplemented")
+        fatalError("Not implemented")
     }
 
     required init(configuration _: URLSessionConfiguration, delegate _: URLSessionDelegate?, delegateQueue _: OperationQueue?) {
-        fatalError("Not emplemented")
+        fatalError("Not implemented")
     }
 
     func dataTask(with request: UBURLRequest, owner: UBURLDataTask) -> URLSessionDataTask? {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `TaskConfig` structure for improved immutability and value handling in network requests.
	- Introduced `MetaData` struct to encapsulate networking task information.
	- Added `Sendable` conformance to various protocols, ensuring safe usage in concurrent contexts.

- **Bug Fixes**
	- Ensured original `TaskConfig` instances remain unchanged during modifications, preventing unintended side effects.
	- Corrected error messages in `DataTaskSessionMock` for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->