### PR TITLE
Fixes push permissions query

### DIFF
--- a/Sources/UBPush/UBPushManager.swift
+++ b/Sources/UBPush/UBPushManager.swift
@@ -281,13 +281,20 @@ open class UBPushManager: NSObject {
     }
 
     /// Querys the current push permissions from the system
-    public func queryPushPermissions(callback: @escaping (Bool) -> Void) {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
+    public func queryPushPermissions(callback: @Sendable @escaping (Bool) -> Void) {
+        UNUserNotificationCenter.current().getNotificationSettings { @Sendable settings in
             let isEnabled = settings.alertSetting == .enabled
             DispatchQueue.main.async {
                 callback(isEnabled)
             }
         }
+    }
+    
+    /// Querys the current push permissions from the system
+    public func queryPushPermissions() async -> Bool {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        let isEnabled = settings.alertSetting == .enabled
+        return isEnabled
     }
 
     // MARK: - Push Registration


### PR DESCRIPTION
- Fixes a runtime crash when calling .getNotificationSettings with swift6.
- Also added an async way to call 'queryPushPermissions'

For explanation see: https://developer.apple.com/forums/thread/764777?answerId=807248022#807248022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an asynchronous method for querying push permissions, enhancing the user experience by providing non-blocking checks.
  
- **Improvements**
	- Refined error handling for push permission requests to improve robustness.
	- Enhanced management of push tokens during registration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->