### PR TITLE
add option for provisional push and app settings to push manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/UbiqueInnovation/ios-local-networking.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-syntax", .upToNextMajor(from: "509.0.0")),
     ],
     targets: [
         .target(

--- a/Sources/UBPush/UBPushManager.swift
+++ b/Sources/UBPush/UBPushManager.swift
@@ -189,6 +189,8 @@ open class UBPushManager: NSObject {
     ///     - callback: The callback for handling the result of the request
     public func requestPushPermissions(includingCritical: Bool = false,
                                        includingNotificationSettings: Bool = false,
+                                       provisional: Bool = false,
+                                       providesAppSettings: Bool = false,
                                        callback: @escaping PermissionRequestCallback) {
         if let previousCallback = permissionRequestCallback {
             Self.logger.error("Tried to request push permissions while other request pending")
@@ -200,7 +202,12 @@ open class UBPushManager: NSObject {
         latestPushRequest += 1
         let currentPushRequest = latestPushRequest
 
-        let options = makeAuthorizationOptions(includingCritical: includingCritical, includingNotificationSettings: includingNotificationSettings)
+        let options = makeAuthorizationOptions(
+            includingCritical: includingCritical,
+            includingNotificationSettings: includingNotificationSettings,
+            provisional: provisional,
+            providesAppSettings: providesAppSettings
+        )
         UNUserNotificationCenter.current().requestAuthorization(options: options) { @Sendable granted, _ in
 
             guard granted else {
@@ -230,7 +237,7 @@ open class UBPushManager: NSObject {
     }
 
     /// :nodoc:
-    private func makeAuthorizationOptions(includingCritical: Bool, includingNotificationSettings: Bool) -> UNAuthorizationOptions {
+    private func makeAuthorizationOptions(includingCritical: Bool, includingNotificationSettings: Bool, provisional: Bool, providesAppSettings: Bool) -> UNAuthorizationOptions {
         var options: UNAuthorizationOptions = [.alert, .badge, .sound]
 
         if includingCritical {
@@ -238,6 +245,14 @@ open class UBPushManager: NSObject {
         }
 
         if includingNotificationSettings {
+            options.insert(.providesAppNotificationSettings)
+        }
+
+        if provisional {
+            options.insert(.provisional)
+        }
+
+        if providesAppSettings {
             options.insert(.providesAppNotificationSettings)
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced push notification permission request with more granular control
	- Added options for provisional and app settings in push permissions

- **Dependency Changes**
	- Removed Swift Syntax package dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->