### PR TITLE
ASK: Deprecates and fixes ub_keyboardLayoutGuide

### DIFF
--- a/Sources/UBUserInterface/Keyboard/KeyboardLayoutGuide+UIKit.swift
+++ b/Sources/UBUserInterface/Keyboard/KeyboardLayoutGuide+UIKit.swift
@@ -12,6 +12,7 @@ public extension UIView {
     ///
     /// When the view is visible onscreen, this guide reflects the portion of the view that is covered by the keyboard. If the view is not currently installed in a view hierarchy, or is not yet visible onscreen, the layout guide edges are equal to the edges of the view.
     /// - Note: It is necessary to call `initializeForKeyboardLayoutGuide()` on `UIWindow` at the launch of the app in order to instanciate the listening correctly. Failing to do so will crash the app.
+    @available(iOS, deprecated: 15.0, message: "Use UIView.keyboardLayoutGuide on iOS 15 and later.")
     var ub_keyboardLayoutGuide: UILayoutGuide {
         if let existingGuide = layoutGuides.first(where: { $0 is ViewKeyboardLayoutGuide }) {
             return existingGuide
@@ -26,6 +27,7 @@ public extension UIView {
 
 extension UIWindow {
     /// Call this function at the launch of the app in order to setup the monitoring of the keyboard on the Window/
+    @available(iOS, deprecated: 15.0, message: "Use UIView.keyboardLayoutGuide on iOS 15 and later.")
     public func initializeForKeyboardLayoutGuide() {
         guard layoutGuides.contains(where: { $0 is WindowKeyboardLayoutGuide }) == false else {
             return

--- a/Sources/UBUserInterface/Keyboard/KeyboardLayoutGuide+UIKit.swift
+++ b/Sources/UBUserInterface/Keyboard/KeyboardLayoutGuide+UIKit.swift
@@ -12,7 +12,8 @@ public extension UIView {
     ///
     /// When the view is visible onscreen, this guide reflects the portion of the view that is covered by the keyboard. If the view is not currently installed in a view hierarchy, or is not yet visible onscreen, the layout guide edges are equal to the edges of the view.
     /// - Note: It is necessary to call `initializeForKeyboardLayoutGuide()` on `UIWindow` at the launch of the app in order to instanciate the listening correctly. Failing to do so will crash the app.
-    @available(iOS, deprecated: 15.0, message: "Use UIView.keyboardLayoutGuide on iOS 15 and later.")
+    /// - Note: Unlike `UIView.keyboardLayoutGuide`, this guide collapses to the full bottom edge of the view when the keyboard is hidden. Apple's guide defaults to the bottom safe area unless `usesBottomSafeArea` is set to `false`.
+    @available(iOS, deprecated: 15.0, message: "Use UIView.keyboardLayoutGuide. Note: hidden keyboard falls back to safe-area bottom unless usesBottomSafeArea = false.")
     var ub_keyboardLayoutGuide: UILayoutGuide {
         if let existingGuide = layoutGuides.first(where: { $0 is ViewKeyboardLayoutGuide }) {
             return existingGuide
@@ -27,7 +28,8 @@ public extension UIView {
 
 extension UIWindow {
     /// Call this function at the launch of the app in order to setup the monitoring of the keyboard on the Window/
-    @available(iOS, deprecated: 15.0, message: "Use UIView.keyboardLayoutGuide on iOS 15 and later.")
+    /// - Note: This powers `ub_keyboardLayoutGuide`, whose hidden-keyboard behavior differs from `UIView.keyboardLayoutGuide`: UBKit falls back to the full view bottom, while Apple's guide falls back to the safe-area bottom by default.
+    @available(iOS, deprecated: 15.0, message: "Use UIView.keyboardLayoutGuide. Note: hidden keyboard falls back to safe-area bottom unless usesBottomSafeArea = false.")
     public func initializeForKeyboardLayoutGuide() {
         guard layoutGuides.contains(where: { $0 is WindowKeyboardLayoutGuide }) == false else {
             return

--- a/Sources/UBUserInterface/Keyboard/ViewKeyboardLayoutGuide.swift
+++ b/Sources/UBUserInterface/Keyboard/ViewKeyboardLayoutGuide.swift
@@ -99,8 +99,9 @@ extension ViewKeyboardLayoutGuide {
         defer {
             // Animate alongside the keyboard
             owningView.setNeedsLayout()
-            keyboardInfo.animateAlongsideKeyboard {
-                owningView.layoutIfNeeded()
+            keyboardInfo.animateAlongsideKeyboard { [weak owningView] in
+                owningView?.setNeedsLayout()
+                owningView?.layoutIfNeeded()
             }
         }
 

--- a/Sources/UBUserInterface/Keyboard/WindowKeyboardLayoutGuide.swift
+++ b/Sources/UBUserInterface/Keyboard/WindowKeyboardLayoutGuide.swift
@@ -65,16 +65,13 @@ extension WindowKeyboardLayoutGuide {
             return
         }
 
-        // convert own frame to window coordinates, frame is in superview's coordinates
-        let owningViewFrame = window.convert(owningView.frame, from: owningView.superview)
-        // calculate the area of own frame that is covered by keyboard
-        var coveredFrame = owningViewFrame.intersection(keyboardInfo.endFrame)
-        // might be rotated, so convert it back
-        coveredFrame = window.convert(coveredFrame, to: owningView.superview)
+        // The owning view is the window itself, so stay in window coordinates.
+        let coveredFrame = window.bounds.intersection(keyboardInfo.endFrame)
 
         topConstraint?.constant = coveredFrame.height
-        keyboardInfo.animateAlongsideKeyboard {
-            owningView.layoutIfNeeded()
+        keyboardInfo.animateAlongsideKeyboard { [weak owningView] in
+            owningView?.setNeedsLayout()
+            owningView?.layoutIfNeeded()
         }
     }
 


### PR DESCRIPTION

- Behebt gewisse Crashes im UBKit-Keyboard-Layout-Guide. Retain cycle wurde gefixet und owningView.superview war immer nil.

- Zusätzlich werden ub_keyboardLayoutGuide und initializeForKeyboardLayoutGuide() ab iOS 15 als deprecated angezeigt, da UIView.keyboardLayoutGuide von UIKit verwendet werden kann. Note: keyboardLayoutGuide geht standardmässig nur bis zur SafeArea.top, während ub_keyboardLayoutGuide diese ignoriert


