### PR TITLE
ASK: Adds CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @UbiqueInnovation/ios


### PR DESCRIPTION
- Fänds glaub noch praktisch, bei UBKIt ein CODEOWNERS file zu haben, damit das ganze iOS team jeweils direkt als reviewer hinzugefügt wird?
- Hab dafür noch ein UBiqueInnovation/ios team erstellt in der GitHub Organization

- Bin nicht sicher ob ein admin noch was einstellen muss in den repo settings? 